### PR TITLE
Enchantment: Add logger to locatr

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ To remove the cache, delete the file at the path specified in `BaseLocatrOptions
 
 #### Logging 
 
-Logging is enabled by default in locatr and it's set to `Info` log level. Pass the `LogConfig` value in the `BaseLocatrOptions` struct.
+Logging is enabled by default in locatr and it's set to `Error` log level. Pass the `LogConfig` value in the `BaseLocatrOptions` struct.
 
 ```
 	options := locatr.BaseLocatrOptions{UseCache: true, LogConfig: locatr.LogConfig{Level: locatr.Debug}}
@@ -181,9 +181,9 @@ Logging is enabled by default in locatr and it's set to `Info` log level. Pass t
 The following log levels are available, in increasing order of priority:
 
 - `Debug`: Logs all messages, info, warn, error.
-- `Info` (Default): Logs informational messages, warnings, and errors.
+- `Info` : Logs informational messages, warnings, and errors.
 - `Warning`: Logs warnings and errors only.
-- `Error`: Logs only error messages.
+- `Error` (Default): Logs only error messages.
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ go get github.com/vertexcover-io/locatr
 - [ Locatr Settings ](#locatr-options)
 - [ LLM Client ](#llm-client)
 - [ Cache Schema & Management ](#cache)
+- [ Logging ](#logging)
 - [ Contributing ](#contributing)
 
 ### Quick Example
@@ -167,6 +168,22 @@ The cache is stored in JSON format. The schema is as follows:
 
 To remove the cache, delete the file at the path specified in `BaseLocatrOptions`'s `CachePath`.
 
+#### Logging 
+
+Logging is enabled by default in locatr and it's set to `Info` log level. Pass the `LogConfig` value in the `BaseLocatrOptions` struct.
+
+```
+	options := locatr.BaseLocatrOptions{UseCache: true, LogConfig: locatr.LogConfig{Level: locatr.Debug}}
+```
+
+#### Available Log Levels
+
+The following log levels are available, in increasing order of priority:
+
+- `Debug`: Logs all messages, info, warn, error.
+- `Info` (Default): Logs informational messages, warnings, and errors.
+- `Warning`: Logs warnings and errors only.
+- `Error`: Logs only error messages.
 
 ### Contributing
 

--- a/doc.go
+++ b/doc.go
@@ -21,6 +21,8 @@ To get started, let's open a new page in the browser using playwright-go.
 		page.Goto("https://hub.docker.com/")
 	}
 
+# LLM Client
+
 After opening a page, we need to create a new LLM client. Currently, we support `anthropic` and `openai`. The `LlmClient` struct is available in `github.com/vertexcover-io/locatr/core`.
 
 	import (
@@ -34,12 +36,17 @@ After opening a page, we need to create a new LLM client. Currently, we support 
 		os.Getenv("LLM_API_KEY"),
 	)
 
+# Options
+
 Once we have an `llmClient`, we need to configure `BaseLocatrOptions`. This struct sets caching and configuration options.
 
 	options := locatr.BaseLocatrOptions{UseCache: true, CachePath: ".locatr.cache"}
 
 - `CachePath` has a default value of ".locatr.cache".
+
 - `UseCache` is false by default. To enable caching, set `UseCache` to `true`.
+
+# Playwright Locatr
 
 Now, we can create a new `PlaywrightLocatr` instance by calling `NewPlaywrightLocatr` with the `page`, `llmClient`, and `options`.
 
@@ -55,6 +62,8 @@ The `GetLocatr` method returns either an error or a Playwright locator object. Y
 	stringToSend := "Python"
 	err = searchBarLocator.Fill(stringToSend)
 
+# Caching
+
 The cache is stored in json format. The schema is as follows:
 
 	{
@@ -69,5 +78,23 @@ The cache is stored in json format. The schema is as follows:
 	}
 
 To remove the cache, you should delete the file at the path specified in `BaseLocatrOptions`.
+
+# Logging
+
+Logging is enabled by default in locatr and it's set to `Info` log level. Pass the `LogConfig` value in the `BaseLocatrOptions` struct.
+
+	options := locatr.BaseLocatrOptions{UseCache: true, LogConfig: locatr.LogConfig{Level: locatr.Debug}}
+
+# Available Log Levels
+
+The following log levels are available, in increasing order of priority:
+
+- Debug: Logs all messages, info, warn, error.
+
+- Info (Default): Logs informational messages, warnings, and errors.
+
+- Warning: Logs warnings and errors only.
+
+- Error: Logs only error messages.
 */
 package locatr

--- a/examples/dockerhub/docker_hub.go
+++ b/examples/dockerhub/docker_hub.go
@@ -48,8 +48,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not create llm client: %v", err)
 	}
-	// options := locatr.BaseLocatrOptions{UseCache: true, LogConfig: locatr.LogConfig{Level: locatr.Debug}}
-	options := locatr.BaseLocatrOptions{UseCache: true}
+	options := locatr.BaseLocatrOptions{UseCache: true, LogConfig: locatr.LogConfig{Level: locatr.Debug}}
 
 	playWrightLocatr := locatr.NewPlaywrightLocatr(page, llmClient, options)
 

--- a/examples/dockerhub/docker_hub.go
+++ b/examples/dockerhub/docker_hub.go
@@ -6,7 +6,6 @@ Example on how to use locatr with playwright to interact with docker hub.
 */
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"time"
@@ -49,6 +48,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not create llm client: %v", err)
 	}
+	// options := locatr.BaseLocatrOptions{UseCache: true, LogConfig: locatr.LogConfig{Level: locatr.Debug}}
 	options := locatr.BaseLocatrOptions{UseCache: true}
 
 	playWrightLocatr := locatr.NewPlaywrightLocatr(page, llmClient, options)
@@ -57,7 +57,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not get locator: %v", err)
 	}
-	fmt.Println(searchBarLocator.InnerHTML())
 	stringToSend := "Python"
 	err = searchBarLocator.Fill(stringToSend)
 	if err != nil {

--- a/examples/steam/steam.go
+++ b/examples/steam/steam.go
@@ -53,7 +53,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not create llm client: %v", err)
 	}
-	options := locatr.BaseLocatrOptions{UseCache: true}
+	options := locatr.BaseLocatrOptions{UseCache: true, LogConfig: locatr.LogConfig{Level: locatr.Silent}}
 
 	playWrightLocatr := locatr.NewPlaywrightLocatr(page, llmClient, options)
 

--- a/locatr.go
+++ b/locatr.go
@@ -91,7 +91,7 @@ func NewBaseLocatr(plugin PluginInterface, llmClient LlmClient, options BaseLoca
 
 func (l *BaseLocatr) addCachedLocatrs(url string, locatrName string, locatrs []string) {
 	if _, ok := l.cachedLocatrs[url]; !ok {
-		l.logger.Debug(fmt.Sprintf("Domain %s not found in cache... Creating new cachedLocatrsDto", url))
+		l.logger.Debug(fmt.Sprintf("Domain %s not found in cache... Creating new cache object", url))
 		l.cachedLocatrs[url] = []cachedLocatrsDto{}
 	}
 	found := false
@@ -276,7 +276,7 @@ func (al *BaseLocatr) locateElementId(htmlDOM string, userReq string) (string, e
 		UserReq: userReq,
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal llmWebInputDto json: %v", err)
+		return "", fmt.Errorf("failed to marshal web input json: %v", err)
 	}
 
 	prompt := fmt.Sprintf("%s%s", string(systemPrompt), string(jsonData))

--- a/locatr.go
+++ b/locatr.go
@@ -76,6 +76,9 @@ func NewBaseLocatr(plugin PluginInterface, llmClient LlmClient, options BaseLoca
 	if len(options.CachePath) == 0 {
 		options.CachePath = DEFAULT_CACHE_PATH
 	}
+	if options.LogConfig.Writer == nil {
+		options.LogConfig.Writer = DefaultLogWriter
+	}
 	return &BaseLocatr{
 		plugin:        plugin,
 		llmClient:     llmClient,

--- a/logger.go
+++ b/logger.go
@@ -20,6 +20,13 @@ const (
 	Debug
 )
 
+var (
+	infoStr  = "INFO: %s"
+	warnStr  = "WARN: %s"
+	errorStr = "ERROR: %s"
+	debugStr = "DEBUG: %s"
+)
+
 type Writer interface {
 	Printf(string, ...interface{})
 }
@@ -40,8 +47,7 @@ type logInterface interface {
 }
 
 type logger struct {
-	config                               LogConfig
-	infoStr, warnStr, errorStr, debugStr string
+	config LogConfig
 	Writer
 }
 
@@ -57,39 +63,29 @@ func (l *logger) log(level LogLevel, formatStr, message string) {
 }
 
 func (l *logger) Info(message string) {
-	l.log(Info, l.infoStr, message)
+	l.log(Info, infoStr, message)
 }
 
 func (l *logger) Warn(message string) {
-	l.log(Warn, l.warnStr, message)
+	l.log(Warn, warnStr, message)
 }
 
 func (l *logger) Error(message string) {
-	l.log(Error, l.errorStr, message)
+	l.log(Error, errorStr, message)
 }
 
 func (l *logger) Debug(message string) {
-	l.log(Debug, l.debugStr, message)
+	l.log(Debug, debugStr, message)
 }
 
 var DefaultLogWriter = log.New(os.Stdout, "\n", log.LstdFlags)
 
 func NewLogger(config LogConfig) logInterface {
-	var (
-		infoStr  = "INFO: %s"
-		warnStr  = "WARN: %s"
-		errorStr = "ERROR: %s"
-		debugStr = "DEBUG: %s"
-	)
 	if config.Level == 0 {
 		config.Level = Info
 	}
 	return &logger{
-		config:   config,
-		infoStr:  infoStr,
-		warnStr:  warnStr,
-		errorStr: errorStr,
-		debugStr: debugStr,
-		Writer:   config.Writer,
+		config: config,
+		Writer: config.Writer,
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -1,8 +1,8 @@
 package locatr
 
 import (
-	"fmt"
-	"time"
+	"log"
+	"os"
 )
 
 type LogLevel int
@@ -32,14 +32,14 @@ type logInterface interface {
 	Error(string)
 	Debug(string)
 }
+type Writer interface {
+	Printf(string, ...interface{})
+}
 
 type logger struct {
 	config                               LogConfig
 	infoStr, warnStr, errorStr, debugStr string
-}
-
-func getCurrentTime() string {
-	return time.Now().Format("2006-01-02 15:04:05")
+	Writer
 }
 
 func (l *logger) LogMode(level LogLevel) logInterface {
@@ -49,8 +49,7 @@ func (l *logger) LogMode(level LogLevel) logInterface {
 
 func (l *logger) log(level LogLevel, formatStr, message string) {
 	if l.config.Level >= level {
-		logMessage := fmt.Sprintf(formatStr, getCurrentTime(), message)
-		fmt.Println(logMessage)
+		l.Printf(formatStr, message)
 	}
 }
 
@@ -72,10 +71,10 @@ func (l *logger) Debug(message string) {
 
 func NewLogger(config LogConfig) logInterface {
 	var (
-		infoStr  = "INFO: %s %s"
-		warnStr  = "WARN: %s %s"
-		errorStr = "ERROR: %s %s"
-		debugStr = "DEBUG: %s %s"
+		infoStr  = "INFO: %s"
+		warnStr  = "WARN: %s"
+		errorStr = "ERROR: %s"
+		debugStr = "DEBUG: %s"
 	)
 	if config.Level == 0 {
 		config.Level = Info
@@ -86,5 +85,6 @@ func NewLogger(config LogConfig) logInterface {
 		warnStr:  warnStr,
 		errorStr: errorStr,
 		debugStr: debugStr,
+		Writer:   log.New(os.Stdout, "\n", log.LstdFlags),
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -20,9 +20,15 @@ const (
 	Debug
 )
 
+type Writer interface {
+	Printf(string, ...interface{})
+}
+
 type LogConfig struct {
 	// Level is the log level
 	Level LogLevel
+	// Writer is the writer to write logs to
+	Writer Writer
 }
 
 type logInterface interface {
@@ -31,9 +37,6 @@ type logInterface interface {
 	Warn(string)
 	Error(string)
 	Debug(string)
-}
-type Writer interface {
-	Printf(string, ...interface{})
 }
 
 type logger struct {
@@ -69,6 +72,8 @@ func (l *logger) Debug(message string) {
 	l.log(Debug, l.debugStr, message)
 }
 
+var DefaultLogWriter = log.New(os.Stdout, "\n", log.LstdFlags)
+
 func NewLogger(config LogConfig) logInterface {
 	var (
 		infoStr  = "INFO: %s"
@@ -85,6 +90,6 @@ func NewLogger(config LogConfig) logInterface {
 		warnStr:  warnStr,
 		errorStr: errorStr,
 		debugStr: debugStr,
-		Writer:   log.New(os.Stdout, "\n", log.LstdFlags),
+		Writer:   config.Writer,
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,90 @@
+package locatr
+
+import (
+	"fmt"
+	"time"
+)
+
+type LogLevel int
+
+const (
+	// Silent will not log anything
+	Silent LogLevel = iota + 1
+	// Error will log only errors
+	Error
+	// Warn will log errors and warnings
+	Warn
+	// Info will log errors, warnings and info
+	Info
+	// Debug will log everything
+	Debug
+)
+
+type LogConfig struct {
+	// Level is the log level
+	Level LogLevel
+}
+
+type logInterface interface {
+	LogMode(LogLevel) logInterface
+	Info(string)
+	Warn(string)
+	Error(string)
+	Debug(string)
+}
+
+type logger struct {
+	config                               LogConfig
+	infoStr, warnStr, errorStr, debugStr string
+}
+
+func getCurrentTime() string {
+	return time.Now().Format("2006-01-02 15:04:05")
+}
+
+func (l *logger) LogMode(level LogLevel) logInterface {
+	l.config.Level = level
+	return l
+}
+
+func (l *logger) log(level LogLevel, formatStr, message string) {
+	if l.config.Level >= level {
+		logMessage := fmt.Sprintf(formatStr, getCurrentTime(), message)
+		fmt.Println(logMessage)
+	}
+}
+
+func (l *logger) Info(message string) {
+	l.log(Info, l.infoStr, message)
+}
+
+func (l *logger) Warn(message string) {
+	l.log(Warn, l.warnStr, message)
+}
+
+func (l *logger) Error(message string) {
+	l.log(Error, l.errorStr, message)
+}
+
+func (l *logger) Debug(message string) {
+	l.log(Debug, l.debugStr, message)
+}
+
+func NewLogger(config LogConfig) logInterface {
+	var (
+		infoStr  = "INFO: %s %s"
+		warnStr  = "WARN: %s %s"
+		errorStr = "ERROR: %s %s"
+		debugStr = "DEBUG: %s %s"
+	)
+	if config.Level == 0 {
+		config.Level = Info
+	}
+	return &logger{
+		config:   config,
+		infoStr:  infoStr,
+		warnStr:  warnStr,
+		errorStr: errorStr,
+		debugStr: debugStr,
+	}
+}

--- a/logger.go
+++ b/logger.go
@@ -82,7 +82,7 @@ var DefaultLogWriter = log.New(os.Stdout, "\n", log.LstdFlags)
 
 func NewLogger(config LogConfig) logInterface {
 	if config.Level == 0 {
-		config.Level = Info
+		config.Level = Error
 	}
 	return &logger{
 		config: config,


### PR DESCRIPTION
1. Added logging config option in `BaseLocatrOptions`. 
2. Added `locatr.LogConfig` for log configuration. 
3. Logger is only available in the `BaseLocatr` Struct.

The following log levels are available, in increasing order of priority:

- `Debug`: Logs all messages, info, warn, error.
- `Info` (Default): Logs informational messages, warnings, and errors.
- `Warning`: Logs warnings and errors only.
- `Error`: Logs only error messages.
