### PR TITLE
Enchantment: Add logger to locatr (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ go get github.com/vertexcover-io/locatr
 - [ Locatr Settings ](#locatr-options)
 - [ LLM Client ](#llm-client)
 - [ Cache Schema & Management ](#cache)
+- [ Logging ](#logging)
 - [ Contributing ](#contributing)
 
 ### Quick Example
@@ -167,6 +168,22 @@ The cache is stored in JSON format. The schema is as follows:
 
 To remove the cache, delete the file at the path specified in `BaseLocatrOptions`'s `CachePath`.
 
+#### Logging 
+
+Logging is enabled by default in locatr and it's set to `Error` log level. Pass the `LogConfig` value in the `BaseLocatrOptions` struct.
+
+```
+	options := locatr.BaseLocatrOptions{UseCache: true, LogConfig: locatr.LogConfig{Level: locatr.Debug}}
+```
+
+#### Available Log Levels
+
+The following log levels are available, in increasing order of priority:
+
+- `Debug`: Logs all messages, info, warn, error.
+- `Info` : Logs informational messages, warnings, and errors.
+- `Warning`: Logs warnings and errors only.
+- `Error` (Default): Logs only error messages.
 
 ### Contributing
 

--- a/doc.go
+++ b/doc.go
@@ -21,6 +21,8 @@ To get started, let's open a new page in the browser using playwright-go.
 		page.Goto("https://hub.docker.com/")
 	}
 
+# LLM Client
+
 After opening a page, we need to create a new LLM client. Currently, we support `anthropic` and `openai`. The `LlmClient` struct is available in `github.com/vertexcover-io/locatr/core`.
 
 	import (
@@ -34,12 +36,17 @@ After opening a page, we need to create a new LLM client. Currently, we support 
 		os.Getenv("LLM_API_KEY"),
 	)
 
+# Options
+
 Once we have an `llmClient`, we need to configure `BaseLocatrOptions`. This struct sets caching and configuration options.
 
 	options := locatr.BaseLocatrOptions{UseCache: true, CachePath: ".locatr.cache"}
 
 - `CachePath` has a default value of ".locatr.cache".
+
 - `UseCache` is false by default. To enable caching, set `UseCache` to `true`.
+
+# Playwright Locatr
 
 Now, we can create a new `PlaywrightLocatr` instance by calling `NewPlaywrightLocatr` with the `page`, `llmClient`, and `options`.
 
@@ -55,6 +62,8 @@ The `GetLocatr` method returns either an error or a Playwright locator object. Y
 	stringToSend := "Python"
 	err = searchBarLocator.Fill(stringToSend)
 
+# Caching
+
 The cache is stored in json format. The schema is as follows:
 
 	{
@@ -69,5 +78,23 @@ The cache is stored in json format. The schema is as follows:
 	}
 
 To remove the cache, you should delete the file at the path specified in `BaseLocatrOptions`.
+
+# Logging
+
+Logging is enabled by default in locatr and it's set to `Info` log level. Pass the `LogConfig` value in the `BaseLocatrOptions` struct.
+
+	options := locatr.BaseLocatrOptions{UseCache: true, LogConfig: locatr.LogConfig{Level: locatr.Debug}}
+
+# Available Log Levels
+
+The following log levels are available, in increasing order of priority:
+
+- Debug: Logs all messages, info, warn, error.
+
+- Info (Default): Logs informational messages, warnings, and errors.
+
+- Warning: Logs warnings and errors only.
+
+- Error: Logs only error messages.
 */
 package locatr

--- a/examples/dockerhub/docker_hub.go
+++ b/examples/dockerhub/docker_hub.go
@@ -6,7 +6,6 @@ Example on how to use locatr with playwright to interact with docker hub.
 */
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"time"
@@ -49,7 +48,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not create llm client: %v", err)
 	}
-	options := locatr.BaseLocatrOptions{UseCache: true}
+	options := locatr.BaseLocatrOptions{UseCache: true, LogConfig: locatr.LogConfig{Level: locatr.Debug}}
 
 	playWrightLocatr := locatr.NewPlaywrightLocatr(page, llmClient, options)
 
@@ -57,7 +56,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not get locator: %v", err)
 	}
-	fmt.Println(searchBarLocator.InnerHTML())
 	stringToSend := "Python"
 	err = searchBarLocator.Fill(stringToSend)
 	if err != nil {

--- a/examples/steam/steam.go
+++ b/examples/steam/steam.go
@@ -53,7 +53,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not create llm client: %v", err)
 	}
-	options := locatr.BaseLocatrOptions{UseCache: true}
+	options := locatr.BaseLocatrOptions{UseCache: true, LogConfig: locatr.LogConfig{Level: locatr.Silent}}
 
 	playWrightLocatr := locatr.NewPlaywrightLocatr(page, llmClient, options)
 

--- a/locatr.go
+++ b/locatr.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 )
@@ -26,6 +25,8 @@ var (
 	ErrUnableToLocateElementId     = errors.New("unable to locate element ID")
 	ErrInvalidElementIdGenerated   = errors.New("invalid element ID generated")
 	ErrUnableToFindValidLocator    = errors.New("unable to find valid locator")
+	ErrFailedToWriteCache          = errors.New("failed to write cache")
+	ErrFailedToMarshalJson         = errors.New("failed to marshal json")
 )
 
 type IdToLocatorMap map[string][]string
@@ -54,6 +55,7 @@ type BaseLocatr struct {
 	options       BaseLocatrOptions
 	cachedLocatrs map[string][]cachedLocatrsDto
 	initialized   bool
+	logger        logInterface
 }
 
 // BaseLocatrOptions is a struct that holds all the options for the locatr package
@@ -62,6 +64,8 @@ type BaseLocatrOptions struct {
 	CachePath string
 	// UseCache is a flag to enable/disable cache
 	UseCache bool
+	// LogConfig is the log configuration
+	LogConfig LogConfig
 }
 
 // NewBaseLocatr creates a new instance of BaseLocatr
@@ -72,56 +76,67 @@ func NewBaseLocatr(plugin PluginInterface, llmClient LlmClient, options BaseLoca
 	if len(options.CachePath) == 0 {
 		options.CachePath = DEFAULT_CACHE_PATH
 	}
+	if options.LogConfig.Writer == nil {
+		options.LogConfig.Writer = DefaultLogWriter
+	}
 	return &BaseLocatr{
 		plugin:        plugin,
 		llmClient:     llmClient,
 		options:       options,
 		cachedLocatrs: make(map[string][]cachedLocatrsDto),
 		initialized:   false,
+		logger:        NewLogger(options.LogConfig),
 	}
 }
 
 func (l *BaseLocatr) addCachedLocatrs(url string, locatrName string, locatrs []string) {
 	if _, ok := l.cachedLocatrs[url]; !ok {
+		l.logger.Debug(fmt.Sprintf("Domain %s not found in cache... Creating new cache object", url))
 		l.cachedLocatrs[url] = []cachedLocatrsDto{}
 	}
 	found := false
 	for i, v := range l.cachedLocatrs[url] {
 		if v.LocatrName == locatrName {
+			l.logger.Debug(fmt.Sprintf("Found locatr %s in cache... Updating locators", locatrName))
 			l.cachedLocatrs[url][i].Locatrs = GetUniqueStringArray(append(l.cachedLocatrs[url][i].Locatrs, locatrs...))
 			return
 		}
 	}
 	if !found {
+		l.logger.Debug(fmt.Sprintf("Locatr %s not found in cache... Creating new locatr", locatrName))
 		l.cachedLocatrs[url] = append(l.cachedLocatrs[url], cachedLocatrsDto{LocatrName: locatrName, Locatrs: locatrs})
 	}
 }
 
 func (l *BaseLocatr) initializeState() {
 	if l.initialized || !l.options.UseCache {
+		l.logger.Debug("Cache disabled or already initialized")
 		return
 	}
 	err := l.loadLocatorsCache(l.options.CachePath)
 	if err != nil {
-		log.Println(err)
+		l.logger.Error(fmt.Sprintf("Failed to load cache: %v", err))
 		return
 	}
-	log.Println("Cache loaded successfully")
+	l.logger.Debug("Cache loaded successfully")
 	l.initialized = true
 }
 func (l *BaseLocatr) getLocatrsFromState(key string, currentUrl string) ([]string, error) {
 	if locatrs, ok := l.cachedLocatrs[currentUrl]; ok {
 		for _, v := range locatrs {
 			if v.LocatrName == key {
+				l.logger.Debug(fmt.Sprintf("Key %s found in cache", key))
 				return v.Locatrs, nil
 			}
 		}
 	}
+	l.logger.Debug(fmt.Sprintf("Key %s not found in cache", key))
 	return nil, errors.New("key not found")
 }
 func (l *BaseLocatr) loadLocatorsCache(cachePath string) error {
 	file, err := os.Open(cachePath)
 	if err != nil {
+		l.logger.Debug(fmt.Sprintf("Cache file not found: %v", err))
 		return nil // ignore this error for now
 	}
 	defer file.Close()
@@ -159,49 +174,63 @@ func (l *BaseLocatr) getLocatorStr(userReq string) (string, error) {
 		return "", ErrUnableToLoadJsScripts
 	}
 	l.initializeState()
-	log.Println("Searching for locator in cache")
+	l.logger.Info(fmt.Sprintf("Getting locator for user request: %s", userReq))
 	currentUrl := l.getCurrentUrl()
 	locators, err := l.getLocatrsFromState(userReq, currentUrl)
 
-	if err == nil && len(locators) > 0 {
-		validLocator, err := l.getValidLocator(locators)
-		if err == nil {
-			log.Println("Cache hit; returning locator")
-			return validLocator, nil
+	if err != nil {
+		l.logger.Error(fmt.Sprintf("Failed to get locators from cache: %v", err))
+	} else {
+		if len(locators) > 0 {
+			validLocator, err := l.getValidLocator(locators)
+			if err == nil {
+				l.logger.Info(fmt.Sprintf("Cache hit, key: %s, value: %s", userReq, validLocator))
+				return validLocator, nil
+			} else {
+				l.logger.Error(fmt.Sprintf("Failed to find valid locator in cache: %v", err))
+			}
+			l.logger.Info("All cached locators are outdated.")
 		}
-		log.Println("All cached locators are outdated.")
+
 	}
 
-	log.Println("Cache miss; going forward with dom minification")
+	l.logger.Info("Cache miss, starting dom minification")
 	minifiedDOM, locatorsMap, err := l.getMinifiedDomAndLocatorMap()
 	if err != nil {
-		return "", err
+		l.logger.Error(fmt.Sprintf("Failed to minify DOM and extract ID locator map: %v", err))
+		return "", ErrUnableToMinifyHtmlDom
 	}
 
-	log.Println("Extracting element ID using LLM")
+	l.logger.Info("Extracting element ID using LLM")
 	elementID, err := l.locateElementId(minifiedDOM.ContentStr(), userReq)
 	if err != nil {
-		return "", err
+		l.logger.Error(fmt.Sprintf("Failed to locate element ID: %v", err))
+		return "", ErrUnableToLocateElementId
 	}
 
 	locators, ok := (*locatorsMap)[elementID]
 	if !ok {
+		l.logger.Error("Invalid element ID generated")
 		return "", ErrInvalidElementIdGenerated
 	}
 
 	validLocators, err := l.getValidLocator(locators)
 	if err != nil {
-		log.Println(err)
+		l.logger.Error(fmt.Sprintf("Failed to find valid locator: %v", err))
 		return "", ErrUnableToFindValidLocator
 	}
 	if l.options.UseCache {
+		l.logger.Info(fmt.Sprintf("Adding locatrs of %s to cache", userReq))
+		l.logger.Debug(fmt.Sprintf("Adding Locars of %s: %v to cache", userReq, locators))
 		l.addCachedLocatrs(currentUrl, userReq, locators)
 		value, err := json.Marshal(l.cachedLocatrs)
 		if err != nil {
-			return "", err
+			l.logger.Error(fmt.Sprintf("Failed to marshal cache: %v", err))
+			return "", fmt.Errorf("%w: %v", ErrFailedToMarshalJson, err)
 		}
 		if err = writeLocatorsToCache(l.options.CachePath, value); err != nil {
-			log.Println(err)
+			l.logger.Error(fmt.Sprintf("Failed to write cache: %v", err))
+			return "", fmt.Errorf("%w: %v", ErrFailedToWriteCache, err)
 		}
 	}
 	return validLocators, nil
@@ -210,6 +239,8 @@ func (l *BaseLocatr) getLocatorStr(userReq string) (string, error) {
 func (l *BaseLocatr) getCurrentUrl() string {
 	if value, err := l.plugin.evaluateJsFunction("window.location.href"); err == nil {
 		return value
+	} else {
+		l.logger.Error(fmt.Sprintf("Failed to get current URL: %v", err))
 	}
 	return ""
 }
@@ -245,7 +276,7 @@ func (al *BaseLocatr) locateElementId(htmlDOM string, userReq string) (string, e
 		UserReq: userReq,
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal llmWebInputDto json: %v", err)
+		return "", fmt.Errorf("failed to marshal web input json: %v", err)
 	}
 
 	prompt := fmt.Sprintf("%s%s", string(systemPrompt), string(jsonData))

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,91 @@
+package locatr
+
+import (
+	"log"
+	"os"
+)
+
+type LogLevel int
+
+const (
+	// Silent will not log anything
+	Silent LogLevel = iota + 1
+	// Error will log only errors
+	Error
+	// Warn will log errors and warnings
+	Warn
+	// Info will log errors, warnings and info
+	Info
+	// Debug will log everything
+	Debug
+)
+
+var (
+	infoStr  = "INFO: %s"
+	warnStr  = "WARN: %s"
+	errorStr = "ERROR: %s"
+	debugStr = "DEBUG: %s"
+)
+
+type Writer interface {
+	Printf(string, ...interface{})
+}
+
+type LogConfig struct {
+	// Level is the log level
+	Level LogLevel
+	// Writer is the writer to write logs to
+	Writer Writer
+}
+
+type logInterface interface {
+	LogMode(LogLevel) logInterface
+	Info(string)
+	Warn(string)
+	Error(string)
+	Debug(string)
+}
+
+type logger struct {
+	config LogConfig
+	Writer
+}
+
+func (l *logger) LogMode(level LogLevel) logInterface {
+	l.config.Level = level
+	return l
+}
+
+func (l *logger) log(level LogLevel, formatStr, message string) {
+	if l.config.Level >= level {
+		l.Printf(formatStr, message)
+	}
+}
+
+func (l *logger) Info(message string) {
+	l.log(Info, infoStr, message)
+}
+
+func (l *logger) Warn(message string) {
+	l.log(Warn, warnStr, message)
+}
+
+func (l *logger) Error(message string) {
+	l.log(Error, errorStr, message)
+}
+
+func (l *logger) Debug(message string) {
+	l.log(Debug, debugStr, message)
+}
+
+var DefaultLogWriter = log.New(os.Stdout, "\n", log.LstdFlags)
+
+func NewLogger(config LogConfig) logInterface {
+	if config.Level == 0 {
+		config.Level = Error
+	}
+	return &logger{
+		config: config,
+		Writer: config.Writer,
+	}
+}


### PR DESCRIPTION
1. Added logging config option in `BaseLocatrOptions`. 
2. Added `locatr.LogConfig` for log configuration. 
3. Logger is only available in the `BaseLocatr` Struct.

The following log levels are available, in increasing order of priority:

- `Debug`: Logs all messages, info, warn, error.
- `Info` (Default): Logs informational messages, warnings, and errors.
- `Warning`: Logs warnings and errors only.
- `Error`: Logs only error messages.
