### PR TITLE
Feature: Create default llm client if not provided in options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not create llm client: %v", err)
 	}
-	options := locatr.BaseLocatrOptions{UseCache: true}
+    options := locatr.BaseLocatrOptions{UseCache: true, LogConfig: locatr.LogConfig{Level: locatr.Silent}, LlmClient: llmClient}
 
-	playWrightlocatr := locatr.NewPlaywrightLocatr(page, llmClient, options)
+	playWrightlocatr := locatr.NewPlaywrightLocatr(page, options)
 
 	searchBarLocator, err := playWrightlocatr.GetLocatr("Search Docker Hub input field")
 	if err != nil {

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ go get github.com/vertexcover-io/locatr
 
 - [ Quick Example ](#quick-example)
 - [ Locatr Settings ](#locatr-options)
-- [ LLM Client ](#llm-client)
+- [ Create LLM Client ](#create-llm-client)
 - [ Cache Schema & Management ](#cache)
 - [ Logging ](#logging)
 - [ Generate Statistics ](#locatr-results)
@@ -124,10 +124,15 @@ func main() {
     - Path to the file where `locatr` results will be saved.
     - If not provided, results will be saved to `DEFAULT_LOCATR_RESULTS_FILE`.
 
-#### LLM Client
+- **LlmClient** (`LlmClientInterface`): 
+    - The `LlmClient` is a wrapper around the llm provider you want to use. Supported providers are `locatr.OpenAI`, `locatr.Anthropic`
+    - It is optional; if not provided in the options, Locatr will automatically create an LlmClient using environment variables. 
+    - The following environment variables will be read to create a default LlmClient:
+        - **LLM_PROVIDER**: Defines which provider's LLM should be utilized (`openai`, `anthropic`).
+        - **LLM_MODEL**: Specifies the model to use 
+        - **LLM_API_KEY**: The API key required to authenticate with the LLM provider.
 
-The `LlmClient` is a wrapper around the llm provider you want to use. Supported providers are `locatr.OpenAI`, `locatr.Anthropic`
-
+#### Create LLM Client
 
 ```go
 import (
@@ -215,7 +220,7 @@ Locatr provides a feature to get all the information about each locatr request m
 
 **Saving Results**
 
-Results can be saved to a file specified by `locatr.BaseLocatrOptions.ResultsFilePath`. If no file path is specified, results are written to `locatr.DEFAULT_LOCATR_RESULTS_PATH`.
+Results can be saved to a file specified by `locatr.BaseLocatrOptions.ResultsFilePath` (`locatr_results.json`). If no file path is specified, results are written to `locatr.DEFAULT_LOCATR_RESULTS_PATH`.
 
 - **To write results to a file**: Use the `playwrightLocatr.WriteResultsToFile` function.
 

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,18 @@
+package locatr
+
+import "errors"
+
+// BaseLocatr Errors
+var (
+	ErrUnableToLoadJsScripts       = errors.New("unable to load JS scripts")
+	ErrUnableToMinifyHtmlDom       = errors.New("unable to minify HTML DOM")
+	ErrUnableToExtractIdLocatorMap = errors.New("unable to extract ID locator map")
+	ErrUnableToLocateElementId     = errors.New("unable to locate element ID")
+	ErrInvalidElementIdGenerated   = errors.New("invalid element ID generated")
+	ErrUnableToFindValidLocator    = errors.New("unable to find valid locator")
+	ErrFailedToWriteCache          = errors.New("failed to write cache")
+	ErrFailedToMarshalJson         = errors.New("failed to marshal json")
+)
+
+// LLM client errors
+var ErrInvalidProviderForLlm = errors.New("invalid provider for llm")

--- a/examples/dockerhub/docker_hub.go
+++ b/examples/dockerhub/docker_hub.go
@@ -48,9 +48,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not create llm client: %v", err)
 	}
-	options := locatr.BaseLocatrOptions{UseCache: true, LogConfig: locatr.LogConfig{Level: locatr.Debug}}
+	options := locatr.BaseLocatrOptions{UseCache: true, LogConfig: locatr.LogConfig{Level: locatr.Debug}, LlmClient: llmClient}
 
-	playWrightLocatr := locatr.NewPlaywrightLocatr(page, llmClient, options)
+	playWrightLocatr := locatr.NewPlaywrightLocatr(page, options)
 
 	searchBarLocator, err := playWrightLocatr.GetLocatr("Search Docker Hub input field")
 	if err != nil {

--- a/examples/github/github.go
+++ b/examples/github/github.go
@@ -48,9 +48,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not create llm client: %v", err)
 	}
-	options := locatr.BaseLocatrOptions{UseCache: true}
+	options := locatr.BaseLocatrOptions{UseCache: true, LlmClient: llmClient}
 
-	locatr := locatr.NewPlaywrightLocatr(page, llmClient, options)
+	locatr := locatr.NewPlaywrightLocatr(page, options)
 
 	codeDropDownLocatr, err := locatr.GetLocatr("<> Code dropdown")
 	if err != nil {

--- a/examples/steam/steam.go
+++ b/examples/steam/steam.go
@@ -53,9 +53,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not create llm client: %v", err)
 	}
-	options := locatr.BaseLocatrOptions{UseCache: true, LogConfig: locatr.LogConfig{Level: locatr.Silent}}
+	options := locatr.BaseLocatrOptions{UseCache: true, LogConfig: locatr.LogConfig{Level: locatr.Silent}, LlmClient: llmClient}
 
-	playWrightLocatr := locatr.NewPlaywrightLocatr(page, llmClient, options)
+	playWrightLocatr := locatr.NewPlaywrightLocatr(page, options)
 
 	searchBarLocator, err := playWrightLocatr.GetLocatr("Search input bar on the steam store.")
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/vertexcover-io/locatr
 
-go 1.22.3
+go 1.23
+
+toolchain go1.23.2
 
 require (
 	github.com/liushuangls/go-anthropic/v2 v2.4.1

--- a/go.mod
+++ b/go.mod
@@ -6,14 +6,17 @@ require (
 	github.com/liushuangls/go-anthropic/v2 v2.4.1
 	github.com/playwright-community/playwright-go v0.4501.1
 	github.com/sashabaranov/go-openai v1.28.1
+	github.com/stretchr/testify v1.9.0
 	gopkg.in/validator.v2 v2.0.1
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/llm.go
+++ b/llm.go
@@ -2,17 +2,13 @@ package locatr
 
 import (
 	"context"
-	"errors"
+	"os"
 	"time"
 
 	"github.com/liushuangls/go-anthropic/v2"
 	"github.com/sashabaranov/go-openai"
 	"gopkg.in/validator.v2"
 )
-
-var ErrInvalidProviderForLlm = errors.New("invalid provider for llm")
-
-type LlmProvider string
 
 const MaxTokens int = 256
 
@@ -144,4 +140,15 @@ func (c *llmClient) openaiRequest(prompt string) (*chatCompletionResponse, error
 	}
 
 	return &completionResponse, nil
+}
+
+func createLlmClientFromEnv() (*llmClient, error) {
+	var provider LlmProvider
+	envProvider := os.Getenv("LLM_PROVIDER")
+	if envProvider == string(OpenAI) {
+		provider = OpenAI
+	} else if envProvider == string(Anthropic) {
+		provider = Anthropic
+	}
+	return NewLlmClient(provider, os.Getenv("LLM_MODEL"), os.Getenv("LLM_API_KEY"))
 }

--- a/llm.go
+++ b/llm.go
@@ -28,11 +28,12 @@ type llmClient struct {
 	model           string      `validate:"min=2,max=50"`
 	openaiClient    *openai.Client
 	anthropicClient *anthropic.Client
-	completions     []chatCompletionResponse
 }
 
 type LlmClientInterface interface {
 	ChatCompletion(prompt string) (*chatCompletionResponse, error)
+	getProvider() LlmProvider
+	getModel() string
 }
 
 type chatCompletionResponse struct {
@@ -52,10 +53,9 @@ type chatCompletionResponse struct {
 // Returns an initialized *llmClient or an error if validation or provider initialization fails.
 func NewLlmClient(provider LlmProvider, model string, apiKey string) (*llmClient, error) {
 	client := &llmClient{
-		apiKey:      apiKey,
-		provider:    provider,
-		model:       model,
-		completions: []chatCompletionResponse{},
+		apiKey:   apiKey,
+		provider: provider,
+		model:    model,
 	}
 	validate := validator.NewValidator()
 	if err := validate.Validate(client); err != nil {
@@ -151,4 +151,12 @@ func createLlmClientFromEnv() (*llmClient, error) {
 		provider = Anthropic
 	}
 	return NewLlmClient(provider, os.Getenv("LLM_MODEL"), os.Getenv("LLM_API_KEY"))
+}
+
+func (c *llmClient) getProvider() LlmProvider {
+	return c.provider
+}
+
+func (c *llmClient) getModel() string {
+	return c.model
 }

--- a/locatr.go
+++ b/locatr.go
@@ -206,10 +206,8 @@ func (l *BaseLocatr) getLocatorStr(userReq string) (string, error) {
 				l.locatrResults = append(l.locatrResults, result)
 				l.logger.Info(fmt.Sprintf("Cache hit, key: %s, value: %s", userReq, validLocator))
 				return validLocator, nil
-			} else {
-				l.logger.Error(fmt.Sprintf("Failed to find valid locator in cache: %v", err))
 			}
-			l.logger.Info("All cached locators are outdated.")
+			l.logger.Error(fmt.Sprintf("Failed to find valid locator in cache: %v", err))
 		}
 
 	}

--- a/locatr_test.go
+++ b/locatr_test.go
@@ -26,8 +26,8 @@ func (m *MockLlmClient) ChatCompletion(prompt string) (*chatCompletionResponse, 
 func TestAddCachedLocatrs(t *testing.T) {
 	mockPlugin := &MockPlugin{}
 	mockLlmClient := &MockLlmClient{}
-	options := BaseLocatrOptions{UseCache: true}
-	baseLocatr := NewBaseLocatr(mockPlugin, mockLlmClient, options)
+	options := BaseLocatrOptions{UseCache: true, LlmClient: mockLlmClient}
+	baseLocatr := NewBaseLocatr(mockPlugin, options)
 
 	tests := []struct {
 		url        string
@@ -79,8 +79,8 @@ func TestAddCachedLocatrs(t *testing.T) {
 func TestInitilizeState(t *testing.T) {
 	mockPlugin := &MockPlugin{}
 	mockLlmClient := &MockLlmClient{}
-	options := BaseLocatrOptions{UseCache: true, CachePath: "test_cache.json"}
-	baseLocatr := NewBaseLocatr(mockPlugin, mockLlmClient, options)
+	options := BaseLocatrOptions{UseCache: true, CachePath: "test_cache.json", LlmClient: mockLlmClient}
+	baseLocatr := NewBaseLocatr(mockPlugin, options)
 
 	// Test when cache is successfully loaded
 	err := os.WriteFile(options.CachePath, []byte(`{"http://example.com":[{"locatr_name":"testLocator","locatrs":["locator1"]}]}`), 0644)
@@ -98,8 +98,8 @@ func TestInitilizeState(t *testing.T) {
 func TestLoadLocatorsCache(t *testing.T) {
 	mockPlugin := &MockPlugin{}
 	mockLlmClient := &MockLlmClient{}
-	options := BaseLocatrOptions{UseCache: true, CachePath: "test_cache.json"}
-	baseLocatr := NewBaseLocatr(mockPlugin, mockLlmClient, options)
+	options := BaseLocatrOptions{UseCache: true, CachePath: "test_cache.json", LlmClient: mockLlmClient}
+	baseLocatr := NewBaseLocatr(mockPlugin, options)
 
 	// Test loading a valid cache file
 	err := os.WriteFile(options.CachePath, []byte(`{"http://example.com":[{"locatr_name":"testLocator","locatrs":["locator1"]}]}`), 0644)
@@ -185,8 +185,8 @@ func TestWriteLocatorsToCache(t *testing.T) {
 func TestGetLocatrsFromState(t *testing.T) {
 	mockPlugin := &MockPlugin{}
 	mockLlmClient := &MockLlmClient{}
-	options := BaseLocatrOptions{UseCache: true}
-	baseLocatr := NewBaseLocatr(mockPlugin, mockLlmClient, options)
+	options := BaseLocatrOptions{UseCache: true, LlmClient: mockLlmClient}
+	baseLocatr := NewBaseLocatr(mockPlugin, options)
 
 	testUrl := "https://example.com"
 	baseLocatr.cachedLocatrs = map[string][]cachedLocatrsDto{

--- a/locatr_test.go
+++ b/locatr_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type MockPlugin struct{}
@@ -21,6 +23,13 @@ type MockLlmClient struct{}
 
 func (m *MockLlmClient) ChatCompletion(prompt string) (*chatCompletionResponse, error) {
 	return nil, nil
+}
+func (m *MockLlmClient) getProvider() LlmProvider {
+	return "test_provider"
+}
+
+func (m *MockLlmClient) getModel() string {
+	return "test_model"
 }
 
 func TestAddCachedLocatrs(t *testing.T) {
@@ -257,4 +266,18 @@ func TestGetLocatrsFromState(t *testing.T) {
 			t.Errorf("Expected locatr %v at position %v, got %v", v, i, locatrs[i])
 		}
 	}
+}
+
+func TestNewBaseLocatrNoLLmClient(t *testing.T) {
+	os.Setenv("LLM_PROVIDER", "openai")
+	os.Setenv("LLM_MODEL", "test_model")
+	os.Setenv("LLM_API_KEY", "test_key")
+	mockPlugin := &MockPlugin{}
+	options := BaseLocatrOptions{UseCache: true}
+	baseLocatr := NewBaseLocatr(mockPlugin, options)
+	if baseLocatr.llmClient == nil {
+		t.Errorf("Expected llmClient, got %v", baseLocatr.llmClient)
+	}
+	assert.Equal(t, baseLocatr.llmClient.getProvider(), OpenAI)
+	assert.Equal(t, baseLocatr.llmClient.getProvider(), "test_model")
 }

--- a/logger.go
+++ b/logger.go
@@ -5,8 +5,6 @@ import (
 	"os"
 )
 
-type LogLevel int
-
 const (
 	// Silent will not log anything
 	Silent LogLevel = iota + 1

--- a/playwright.go
+++ b/playwright.go
@@ -17,12 +17,12 @@ type playwrightLocator struct {
 }
 
 // NewPlaywrightLocatr creates a new playwright locator. Use the returned struct methods to get locators.
-func NewPlaywrightLocatr(page playwright.Page, llmClient LlmClientInterface, options BaseLocatrOptions) *playwrightLocator {
+func NewPlaywrightLocatr(page playwright.Page, options BaseLocatrOptions) *playwrightLocator {
 	pwPlugin := &playwrightPlugin{page: page}
 
 	return &playwrightLocator{
 		page:   page,
-		locatr: NewBaseLocatr(pwPlugin, llmClient, options),
+		locatr: NewBaseLocatr(pwPlugin, options),
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -1,7 +1,13 @@
 package locatr
 
+type IdToLocatorMap map[string][]string
+
 // PluginInterface is an interface that defines the methods that a plugin must implement.
 type PluginInterface interface {
 	evaluateJsScript(scriptContent string) error
 	evaluateJsFunction(function string) (string, error)
 }
+
+type LlmProvider string
+
+type LogLevel int


### PR DESCRIPTION
## Pr includes the following changes
### Changes in `BaseLocatrOptions`. 
We will add the following filed in the struct: `LlmClient LlmClientInterface`. 
If `BaseLocatrOptions.LlmClient` is provided as `nil` then we will create the `llmClient` on our own by reading the following env vars. 

- `LLM_PROVIDER`: The llm provider (options: `openai`, `anthropic`)
- `LLM_MODEL`: The llm model. 
- `LLM_API_KEY`: The api key for the provider. 

### Changes in function implementations 
1. New function `createLlmClientFromEnv` that returns a new `llmCLient` by reading from env. 
2. Remove `llmCLient` as param from `NewPlaywrightLocatr` & `NewBaseLocatr`. 

### Minor changes in code.
1. Create a new file `types.go` for storing all the types. 
2. Create a new file `errors.go` for storing all the errors.
