### PR TITLE
feat: add support for visual analysis mode in appium plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ go get github.com/vertexcover-io/locatr/golang
     ```go
     import "github.com/vertexcover-io/locatr/golang/plugins"
 
-    plugin := plugins.NewPlaywrightPlugin(&page)
+    plugin, err := plugins.NewPlaywrightPlugin(&page)
+    if err != nil {
+        log.Fatalf("failed to create playwright plugin: %v", err)
+    }
     ```
 
 - Selenium
@@ -103,7 +106,10 @@ go get github.com/vertexcover-io/locatr/golang
     ```go
     import "github.com/vertexcover-io/locatr/golang/plugins"
 
-    plugin := plugins.NewSeleniumPlugin(&driver)
+    plugin, err := plugins.NewSeleniumPlugin(&driver)
+    if err != nil {
+        log.Fatalf("failed to create selenium plugin: %v", err)
+    }
     ```
 
 - Appium

--- a/README.md
+++ b/README.md
@@ -12,131 +12,132 @@ go get github.com/vertexcover-io/locatr/golang
 
 ### Initialize an automation plugin of your choice.
 
-- Playwright
-    <details>
-    <summary>Set up a Playwright page</summary>
+#### Playwright
+<details>
+<summary>Set up a Playwright page</summary>
 
-    ```go
-    import (
-        "log"
+```go
+import (
+    "log"
 
-        "github.com/playwright-community/playwright-go"
-    )
+    "github.com/playwright-community/playwright-go"
+)
 
-    pw, err := playwright.Run()
-    if err != nil {
-        log.Fatalf("could not start Playwright: %v", err)
-    }
-    
-    // --- Launch a browser ---
-    browser, err := pw.Chromium.Launch(
-        playwright.BrowserTypeLaunchOptions{Headless: playwright.Bool(false)},
-    )
-    // OR, --- Connect to a browser over CDP ---
-    browser, err := pw.Chromium.ConnectOverCDP("<cdp-session-url>")
+pw, err := playwright.Run()
+if err != nil {
+    log.Fatalf("could not start Playwright: %v", err)
+}
 
-    if err != nil {
-        log.Fatalf("could not connect to browser: %v", err)
-    }
+// --- Launch a browser ---
+browser, err := pw.Chromium.Launch(
+    playwright.BrowserTypeLaunchOptions{Headless: playwright.Bool(false)},
+)
+// OR, --- Connect to a browser over CDP ---
+browser, err := pw.Chromium.ConnectOverCDP("<cdp-session-url>")
 
-    browserContext, err := browser.NewContext(
-        playwright.BrowserNewContextOptions{BypassCSP: playwright.Bool(true)},
-    )
-    if err != nil {
-        log.Fatalf("could not create browser context: %v", err)
-    }
+if err != nil {
+    log.Fatalf("could not connect to browser: %v", err)
+}
 
-    page, err := browserContext.NewPage()
-    if err != nil {
-        log.Fatalf("could not create new page: %v", err)
-    }
+browserContext, err := browser.NewContext(
+    playwright.BrowserNewContextOptions{BypassCSP: playwright.Bool(true)},
+)
+if err != nil {
+    log.Fatalf("could not create browser context: %v", err)
+}
 
-    if _, err := page.Goto("https://github.com/vertexcover-io/locatr"); err != nil {
-        log.Fatalf("failed to load URL: %v", err)
-    }
-    ```
-    </details>
-    
-    ```go
-    import "github.com/vertexcover-io/locatr/golang/plugins"
+page, err := browserContext.NewPage()
+if err != nil {
+    log.Fatalf("could not create new page: %v", err)
+}
 
-    plugin, err := plugins.NewPlaywrightPlugin(&page)
-    if err != nil {
-        log.Fatalf("failed to create playwright plugin: %v", err)
-    }
-    ```
+if _, err := page.Goto("https://github.com/vertexcover-io/locatr"); err != nil {
+    log.Fatalf("failed to load URL: %v", err)
+}
+```
+</details>
 
-- Selenium
-    > Note: Make sure to use `--force-device-scale-factor=1` flag when launching the browser for visual analysis mode to work correctly.
+```go
+import "github.com/vertexcover-io/locatr/golang/plugins"
 
-    <details>
-    <summary>Set up a Selenium driver</summary>
+plugin, err := plugins.NewPlaywrightPlugin(&page)
+if err != nil {
+    log.Fatalf("failed to create playwright plugin: %v", err)
+}
+```
 
-    ```go
-    import (
-        "log"
+#### Selenium
 
-        "github.com/vertexcover-io/selenium"
-        "github.com/vertexcover-io/selenium/chrome"
-    )
-    service, err := selenium.NewChromeDriverService(
-        "path/to/chromedriver-executable", 4444,
-    )
-    if err != nil {
-        log.Fatalf("failed to create service: %v", err)
-    }
+> Note: Make sure to use `--force-device-scale-factor=1` flag when launching the browser for visual analysis mode to work correctly.
 
-    caps := selenium.Capabilities{}
-    caps.AddChrome(chrome.Capabilities{Args: []string{"--force-device-scale-factor=1"}})
+<details>
+<summary>Set up a Selenium driver</summary>
 
-    driver, err := selenium.NewRemote(caps, "")
-    // OR, --- Connect to a remote driver session---
-    driver, err := selenium.ConnectRemote("<url>", "<session-id>")
+```go
+import (
+    "log"
 
-    if err != nil {
-        log.Fatalf("could not connect to driver: %v", err)
-    }
+    "github.com/vertexcover-io/selenium"
+    "github.com/vertexcover-io/selenium/chrome"
+)
+service, err := selenium.NewChromeDriverService(
+    "path/to/chromedriver-executable", 4444,
+)
+if err != nil {
+    log.Fatalf("failed to create service: %v", err)
+}
 
-    if err := driver.Get("https://github.com/vertexcover-io/locatr"); err != nil {
-        log.Fatalf("failed to load URL: %v", err)
-    }
-    ```
-    </details>
+caps := selenium.Capabilities{}
+caps.AddChrome(chrome.Capabilities{Args: []string{"--force-device-scale-factor=1"}})
 
-    ```go
-    import "github.com/vertexcover-io/locatr/golang/plugins"
+driver, err := selenium.NewRemote(caps, "")
+// OR, --- Connect to a remote driver session---
+driver, err := selenium.ConnectRemote("<url>", "<session-id>")
 
-    plugin, err := plugins.NewSeleniumPlugin(&driver)
-    if err != nil {
-        log.Fatalf("failed to create selenium plugin: %v", err)
-    }
-    ```
+if err != nil {
+    log.Fatalf("could not connect to driver: %v", err)
+}
 
-- Appium
-    
-    ```go
-    import "github.com/vertexcover-io/locatr/golang/plugins"
+if err := driver.Get("https://github.com/vertexcover-io/locatr"); err != nil {
+    log.Fatalf("failed to load URL: %v", err)
+}
+```
+</details>
 
-    plugin, err := plugins.NewAppiumPlugin(
-        "<appium-server-url>", "<appium-session-id>",
-    )
-    // OR, --- Pass capabilities to create a new session ---
-    plugin, err := plugins.NewAppiumPlugin(
-        "<appium-server-url>", 
-        map[string]any{
-            "platformName": "Android",
-            "automationName": "UiAutomator2",
-            "deviceName": "emulator-5554",
-            "appPackage": "com.google.android.deskclock",
-            "appActivity": "com.android.deskclock.DeskClock",
-            "language": "en",
-            "locale": "US",
-        },
-    )
-    if err != nil {
-        log.Fatalf("failed to create appium plugin: %v", err)
-    }
-    ```
+```go
+import "github.com/vertexcover-io/locatr/golang/plugins"
+
+plugin, err := plugins.NewSeleniumPlugin(&driver)
+if err != nil {
+    log.Fatalf("failed to create selenium plugin: %v", err)
+}
+```
+
+#### Appium
+
+```go
+import "github.com/vertexcover-io/locatr/golang/plugins"
+
+plugin, err := plugins.NewAppiumPlugin(
+    "<appium-server-url>", "<appium-session-id>",
+)
+// OR, --- Pass capabilities to create a new session ---
+plugin, err := plugins.NewAppiumPlugin(
+    "<appium-server-url>", 
+    map[string]any{
+        "platformName": "Android",
+        "automationName": "UiAutomator2",
+        "deviceName": "emulator-5554",
+        "appPackage": "com.google.android.deskclock",
+        "appActivity": "com.android.deskclock.DeskClock",
+        "language": "en",
+        "locale": "US",
+    },
+)
+if err != nil {
+    log.Fatalf("failed to create appium plugin: %v", err)
+}
+```
 
 ### Create a Locatr instance
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ fmt.Printf("Cost: %v\n", cost)
 ### Highlight the locator
 
 ```go
-imageBytes, err := locatr.Highlight(completion.Locators[0])
+imageBytes, err := locatr.Highlight(completion.Locators[0], nil)
 if err != nil {
     log.Fatalf("failed to highlight element: %v", err)
 }

--- a/README.md
+++ b/README.md
@@ -117,7 +117,22 @@ go get github.com/vertexcover-io/locatr/golang
     ```go
     import "github.com/vertexcover-io/locatr/golang/plugins"
 
-    plugin, err := plugins.NewAppiumPlugin("<appium-url>", "<appium-session-id>")
+    plugin, err := plugins.NewAppiumPlugin(
+        "<appium-server-url>", "<appium-session-id>",
+    )
+    // OR, --- Pass capabilities to create a new session ---
+    plugin, err := plugins.NewAppiumPlugin(
+        "<appium-server-url>", 
+        map[string]any{
+            "platformName": "Android",
+            "automationName": "UiAutomator2",
+            "deviceName": "emulator-5554",
+            "appPackage": "com.google.android.deskclock",
+            "appActivity": "com.android.deskclock.DeskClock",
+            "language": "en",
+            "locale": "US",
+        },
+    )
     if err != nil {
         log.Fatalf("failed to create appium plugin: %v", err)
     }

--- a/eval/main.go
+++ b/eval/main.go
@@ -91,7 +91,11 @@ func runEval(context playwright.BrowserContext, eval *evalConfigYaml, modeString
 	} else {
 		options = append(options, locatr.WithMode(&mode.DOMAnalysisMode{MaxAttempts: 3, ChunksPerAttempt: 3}))
 	}
-	plugin := plugins.NewPlaywrightPlugin(&page)
+	plugin, err := plugins.NewPlaywrightPlugin(&page)
+	if err != nil {
+		logger.Error("Error creating playwright plugin", "error", err)
+		return nil
+	}
 	locatr, err := locatr.NewLocatr(plugin, options...)
 	if err != nil {
 		logger.Error("Error creating locatr", "error", err)

--- a/examples/default-llm-client/main.go
+++ b/examples/default-llm-client/main.go
@@ -41,7 +41,10 @@ func main() {
 	}
 	time.Sleep(5 * time.Second) // wait for page to load
 
-	plugin := plugins.NewPlaywrightPlugin(&page)
+	plugin, err := plugins.NewPlaywrightPlugin(&page)
+	if err != nil {
+		log.Fatal("failed creating playwright plugin", err)
+	}
 	locatr, err := locatr.NewLocatr(plugin, locatr.EnableCache(nil))
 	if err != nil {
 		log.Fatal("failed creating playwright locatr locatr", err)

--- a/examples/dockerhub/docker_hub.go
+++ b/examples/dockerhub/docker_hub.go
@@ -42,7 +42,10 @@ func main() {
 		log.Fatalf("could not create llm client: %v", err)
 	}
 
-	plugin := plugins.NewPlaywrightPlugin(&page)
+	plugin, err := plugins.NewPlaywrightPlugin(&page)
+	if err != nil {
+		log.Fatalf("could not create playwright plugin: %v", err)
+	}
 	locatr, err := locatr.NewLocatr(plugin)
 	sBarCompletion, err := locatr.Locate("Search Docker Hub input field")
 	if err != nil {

--- a/examples/github/github.go
+++ b/examples/github/github.go
@@ -40,7 +40,10 @@ func main() {
 	}
 	time.Sleep(5 * time.Second) // wait for page to load
 
-	plugin := plugins.NewPlaywrightPlugin(&page)
+	plugin, err := plugins.NewPlaywrightPlugin(&page)
+	if err != nil {
+		log.Fatalf("could not create playwright plugin: %v", err)
+	}
 	locatr, err := locatr.NewLocatr(plugin)
 	if err != nil {
 		log.Fatalf("could not create locatr: %v", err)

--- a/examples/selenium/main.go
+++ b/examples/selenium/main.go
@@ -35,7 +35,10 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	plugin := plugins.NewSeleniumPlugin(&wd) // or directly pass the &driver
+	plugin, err := plugins.NewSeleniumPlugin(&wd)
+	if err != nil {
+		log.Fatal(err)
+	}
 	locatr, err := locatr.NewLocatr(plugin)
 	if err != nil {
 		log.Fatal(err)

--- a/examples/steam/steam.go
+++ b/examples/steam/steam.go
@@ -43,7 +43,10 @@ func main() {
 	}
 	time.Sleep(5 * time.Second) // wait for page to load
 
-	plugin := plugins.NewPlaywrightPlugin(&page)
+	plugin, err := plugins.NewPlaywrightPlugin(&page)
+	if err != nil {
+		log.Fatalf("could not create playwright plugin: %v", err)
+	}
 	locatr, err := locatr.NewLocatr(plugin, locatr.EnableCache(nil))
 	if err != nil {
 		log.Fatalf("could not create locatr: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.23.5
 require (
 	github.com/antchfx/xmlquery v1.4.4
 	github.com/anthropics/anthropic-sdk-go v0.2.0-alpha.13
+	github.com/beevik/etree v1.5.0
 	github.com/cohere-ai/cohere-go/v2 v2.12.0
 	github.com/go-resty/resty/v2 v2.16.5
 	github.com/kaptinlin/jsonrepair v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ toolchain go1.23.5
 require (
 	github.com/antchfx/xmlquery v1.4.4
 	github.com/anthropics/anthropic-sdk-go v0.2.0-alpha.13
-	github.com/beevik/etree v1.5.0
 	github.com/cohere-ai/cohere-go/v2 v2.12.0
 	github.com/go-resty/resty/v2 v2.16.5
 	github.com/kaptinlin/jsonrepair v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,6 @@ github.com/aws/aws-sdk-go-v2 v1.30.3 h1:jUeBtG0Ih+ZIFH0F4UkmL9w3cSpaMv9tYYDbzILP
 github.com/aws/aws-sdk-go-v2 v1.30.3/go.mod h1:nIQjQVp5sfpQcTc9mPSr1B0PaWK5ByX9MOoDadSN4lc=
 github.com/aws/smithy-go v1.20.3 h1:ryHwveWzPV5BIof6fyDvor6V3iUL7nTfiTKXHiW05nE=
 github.com/aws/smithy-go v1.20.3/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
-github.com/beevik/etree v1.5.0 h1:iaQZFSDS+3kYZiGoc9uKeOkUY3nYMXOKLl6KIJxiJWs=
-github.com/beevik/etree v1.5.0/go.mod h1:gPNJNaBGVZ9AwsidazFZyygnd+0pAU38N4D+WemwKNs=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/aws/aws-sdk-go-v2 v1.30.3 h1:jUeBtG0Ih+ZIFH0F4UkmL9w3cSpaMv9tYYDbzILP
 github.com/aws/aws-sdk-go-v2 v1.30.3/go.mod h1:nIQjQVp5sfpQcTc9mPSr1B0PaWK5ByX9MOoDadSN4lc=
 github.com/aws/smithy-go v1.20.3 h1:ryHwveWzPV5BIof6fyDvor6V3iUL7nTfiTKXHiW05nE=
 github.com/aws/smithy-go v1.20.3/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
+github.com/beevik/etree v1.5.0 h1:iaQZFSDS+3kYZiGoc9uKeOkUY3nYMXOKLl6KIJxiJWs=
+github.com/beevik/etree v1.5.0/go.mod h1:gPNJNaBGVZ9AwsidazFZyygnd+0pAU38N4D+WemwKNs=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=

--- a/golang/internal/appium/appium_test.go
+++ b/golang/internal/appium/appium_test.go
@@ -188,7 +188,7 @@ func (s *AppiumTestSuite) TestFindElement() {
 				}
 			})
 
-			err := s.client.FindElement(tc.locator)
+			_, err := s.client.FindElement("", tc.locator)
 			if tc.expectedError {
 				assert.Error(t, err)
 			} else {

--- a/golang/internal/appium/appium_test.go
+++ b/golang/internal/appium/appium_test.go
@@ -200,7 +200,7 @@ func (s *AppiumTestSuite) TestFindElement() {
 
 func (s *AppiumTestSuite) TestGetCapabilities() {
 	s.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(s.T(), "/session/test-session-id/", r.URL.Path)
+		assert.Equal(s.T(), "/session/test-session-id", r.URL.Path)
 		assert.Equal(s.T(), http.MethodGet, r.Method)
 
 		err := json.NewEncoder(w).Encode(map[string]interface{}{
@@ -248,7 +248,7 @@ func (s *AppiumTestSuite) TestExecuteScript_ServerError() {
 
 	result, err := s.client.ExecuteScript("test script", []interface{}{})
 	assert.Error(s.T(), err)
-	assert.Contains(s.T(), err.Error(), ErrSessionNotActive.Error())
+	assert.Contains(s.T(), err.Error(), ErrEvaulatingScriptFailed.Error())
 	assert.Nil(s.T(), result)
 }
 

--- a/golang/internal/utils/utils.go
+++ b/golang/internal/utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"image/color"
 	"image/draw"
 	"math"
+	"reflect"
 	"strings"
 
 	"github.com/beevik/etree"
@@ -281,6 +282,40 @@ func GetFloatValue(v any) float64 {
 	default:
 		return float64(v.(int))
 	}
+}
+
+// GetStructFields returns the struct name and field values from an interface.
+// Parameters:
+//   - i: The interface to get the fields from
+//   - fieldNames: The names of the fields to retrieve
+//
+// Returns:
+//   - string: The name of the struct
+//   - map[string]reflect.Value: A map of field names to their reflected values
+//   - error: An error if the interface is not a struct
+func GetStructFields(i any, fieldNames ...string) (structName string, fields map[string]reflect.Value, err error) {
+	v := reflect.ValueOf(i)
+
+	// If it's a pointer, dereference it
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	// Ensure it's a struct
+	if v.Kind() != reflect.Struct {
+		return "", nil, fmt.Errorf("expected struct, got %s", v.Kind())
+	}
+
+	// Get struct name
+	structName = v.Type().Name()
+	fields = make(map[string]reflect.Value)
+
+	// Retrieve requested fields
+	for _, fieldName := range fieldNames {
+		fields[fieldName] = v.FieldByName(fieldName)
+	}
+
+	return structName, fields, nil
 }
 
 // ParseJSON parses a JSON string from a text string and repairs it if possible.

--- a/golang/internal/utils/utils.go
+++ b/golang/internal/utils/utils.go
@@ -415,8 +415,8 @@ func RemapPoint(point *types.Point, originalResolution *types.Resolution, target
 	}
 
 	// Convert padded coordinate to scaled image coordinate.
-	origX := int((point.X - float64(padX)) / scale)
-	origY := int((point.Y - float64(padY)) / scale)
+	origX := int(math.Round((point.X - float64(padX)) / scale))
+	origY := int(math.Round((point.Y - float64(padY)) / scale))
 
 	// Clamp the result to the original image bounds.
 	if origX >= originalResolution.Width {

--- a/golang/internal/utils/utils.go
+++ b/golang/internal/utils/utils.go
@@ -313,9 +313,12 @@ func ScaleAndPadImage(img image.Image, targetResolution *types.Resolution) image
 	origHeight := origBounds.Dy()
 
 	// Compute the scale factor to fit the image into the target dimensions.
-	scale := math.Min(float64(targetResolution.Width)/float64(origWidth), float64(targetResolution.Height)/float64(origHeight))
-	newWidth := int(float64(origWidth) * scale)
-	newHeight := int(float64(origHeight) * scale)
+	scale := math.Min(
+		float64(targetResolution.Width)/float64(origWidth),
+		float64(targetResolution.Height)/float64(origHeight),
+	)
+	newWidth := int(math.Round(float64(origWidth) * scale))
+	newHeight := int(math.Round(float64(origHeight) * scale))
 
 	// Resize the original image.
 	// Here we use a simple nearest neighbor approach; you might want a more sophisticated algorithm.
@@ -323,8 +326,8 @@ func ScaleAndPadImage(img image.Image, targetResolution *types.Resolution) image
 	for y := 0; y < newHeight; y++ {
 		for x := 0; x < newWidth; x++ {
 			// Compute the corresponding pixel in the source image.
-			srcX := int(float64(x) / scale)
-			srcY := int(float64(y) / scale)
+			srcX := int(math.Round(float64(x) / scale))
+			srcY := int(math.Round(float64(y) / scale))
 			// Clamp to the source bounds if necessary.
 			if srcX >= origWidth {
 				srcX = origWidth - 1
@@ -363,8 +366,8 @@ func ScaleAndPadImage(img image.Image, targetResolution *types.Resolution) image
 func RemapPoint(point *types.Point, originalResolution *types.Resolution, targetResolution *types.Resolution) *types.Point {
 	// Compute the scale factor used in Letterbox.
 	scale := math.Min(float64(targetResolution.Width)/float64(originalResolution.Width), float64(targetResolution.Height)/float64(originalResolution.Height))
-	newWidth := int(float64(originalResolution.Width) * scale)
-	newHeight := int(float64(originalResolution.Height) * scale)
+	newWidth := int(math.Round(float64(originalResolution.Width) * scale))
+	newHeight := int(math.Round(float64(originalResolution.Height) * scale))
 
 	// Calculate the padding offsets.
 	padX := (targetResolution.Width - newWidth) / 2

--- a/golang/internal/utils/utils.go
+++ b/golang/internal/utils/utils.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"image"
 	"image/color"
+	"image/draw"
+	"math"
 	"strings"
 
+	"github.com/beevik/etree"
 	"github.com/kaptinlin/jsonrepair"
 	"github.com/vertexcover-io/locatr/golang/types"
 	"golang.org/x/net/html"
@@ -130,7 +133,70 @@ func SortRerankChunks(chunks []string, results []types.RerankResult) []string {
 	return finalChunks
 }
 
-// ExtractFirstUniqueID finds and returns the first ID attribute from a top-level element in an HTML fragment.
+// ExtractFirstUniqueXMLID finds and returns the first ID attribute from a top-level element in an XML fragment.
+// Parameters:
+//   - xmlFragment: A string containing XML markup to analyze
+//
+// Returns:
+//   - string: The first ID attribute value found
+//   - error: If no ID is found or if XML parsing fails
+//
+// The function works by:
+// 1. Wrapping the fragment in a root element for proper parsing
+// 2. Creating a DOM tree from the XML
+// 3. Traversing the tree to find the first element with a non-empty ID attribute
+func ExtractFirstUniqueXMLID(xmlFragment string) (string, error) {
+	// Handle empty input
+	if strings.TrimSpace(xmlFragment) == "" {
+		return "", errors.New("empty XML fragment provided")
+	}
+
+	// Since we need to check children when IDs are empty, a streaming approach won't work
+	// We need to build a proper DOM tree, similar to the HTML version
+	wrappedXML := "<root>" + xmlFragment + "</root>"
+
+	// Parse the XML into a DOM tree
+	doc := etree.NewDocument()
+	if err := doc.ReadFromString(wrappedXML); err != nil {
+		return "", fmt.Errorf("error parsing XML: %w", err)
+	}
+
+	// Get the root element we added
+	root := doc.Root()
+	if root == nil {
+		return "", errors.New("failed to parse XML structure")
+	}
+
+	// Define a recursive function to find the first non-empty ID
+	var findFirstNonEmptyID func(*etree.Element) string
+	findFirstNonEmptyID = func(element *etree.Element) string {
+		// Check if current element has an ID
+		id := element.SelectAttrValue("id", "")
+		if id != "" {
+			return id
+		}
+
+		// If ID is empty or not present, check children
+		for _, child := range element.ChildElements() {
+			if childID := findFirstNonEmptyID(child); childID != "" {
+				return childID
+			}
+		}
+
+		return ""
+	}
+
+	// Start the search from the root's children (skipping our artificial root)
+	for _, child := range root.ChildElements() {
+		if id := findFirstNonEmptyID(child); id != "" {
+			return id, nil
+		}
+	}
+
+	return "", errors.New("no non-empty ID attribute found in the XML fragment")
+}
+
+// ExtractFirstUniqueHTMLID finds and returns the first ID attribute from a top-level element in an HTML fragment.
 // Parameters:
 //   - htmlFragment: A string containing HTML markup to analyze
 //
@@ -142,7 +208,7 @@ func SortRerankChunks(chunks []string, results []types.RerankResult) []string {
 // 1. Wrapping the fragment in a root element for proper parsing
 // 2. Creating a DOM tree from the HTML
 // 3. Traversing the tree to find the first element with an ID attribute
-func ExtractFirstUniqueID(htmlFragment string) (string, error) {
+func ExtractFirstUniqueHTMLID(htmlFragment string) (string, error) {
 	wrappedHTML := "<root>" + htmlFragment + "</root>"
 	doc, err := html.Parse(strings.NewReader(wrappedHTML))
 	if err != nil {
@@ -230,6 +296,118 @@ func ParseJSON(text string) (string, error) {
 	text = strings.TrimSuffix(text, "```")
 
 	return jsonrepair.JSONRepair(text)
+}
+
+// ScaleAndPadImage scales an image while maintaining aspect ratio and adds off-white padding to fit the target resolution.
+//
+// Parameters:
+//   - input: The input image in bytes
+//   - targetResolution: The target resolution
+//
+// Returns:
+//   - image.Image: The scaled and padded image
+//   - error: Any error that occurred during the scaling and padding
+func ScaleAndPadImage(img image.Image, targetResolution *types.Resolution) image.Image {
+	origBounds := img.Bounds()
+	origWidth := origBounds.Dx()
+	origHeight := origBounds.Dy()
+
+	// Compute the scale factor to fit the image into the target dimensions.
+	scale := math.Min(float64(targetResolution.Width)/float64(origWidth), float64(targetResolution.Height)/float64(origHeight))
+	newWidth := int(float64(origWidth) * scale)
+	newHeight := int(float64(origHeight) * scale)
+
+	// Resize the original image.
+	// Here we use a simple nearest neighbor approach; you might want a more sophisticated algorithm.
+	resized := image.NewRGBA(image.Rect(0, 0, newWidth, newHeight))
+	for y := 0; y < newHeight; y++ {
+		for x := 0; x < newWidth; x++ {
+			// Compute the corresponding pixel in the source image.
+			srcX := int(float64(x) / scale)
+			srcY := int(float64(y) / scale)
+			// Clamp to the source bounds if necessary.
+			if srcX >= origWidth {
+				srcX = origWidth - 1
+			}
+			if srcY >= origHeight {
+				srcY = origHeight - 1
+			}
+			resized.Set(x, y, img.At(srcX+origBounds.Min.X, srcY+origBounds.Min.Y))
+		}
+	}
+
+	// Create a new image with the target dimensions, filling it with black.
+	padded := image.NewRGBA(image.Rect(0, 0, targetResolution.Width, targetResolution.Height))
+	draw.Draw(padded, padded.Bounds(), &image.Uniform{color.Black}, image.Point{}, draw.Src)
+
+	// Calculate padding offsets to center the resized image.
+	padX := (targetResolution.Width - newWidth) / 2
+	padY := (targetResolution.Height - newHeight) / 2
+
+	// Draw the resized image onto the padded image.
+	offsetRect := image.Rect(padX, padY, padX+newWidth, padY+newHeight)
+	draw.Draw(padded, offsetRect, resized, image.Point{}, draw.Over)
+
+	return padded
+}
+
+// RemapPoint maps a point from the padded image coordinates back to the original image coordinates.
+//
+// Parameters:
+//   - point: The point in the padded image (e.g., where the user clicked)
+//   - originalResolution: The resolution of the original image
+//   - targetResolution: The resolution of the target image
+//
+// Returns:
+//   - *types.Point: The remapped point in the original image's coordinates
+func RemapPoint(point *types.Point, originalResolution *types.Resolution, targetResolution *types.Resolution) *types.Point {
+	// Compute the scale factor used in Letterbox.
+	scale := math.Min(float64(targetResolution.Width)/float64(originalResolution.Width), float64(targetResolution.Height)/float64(originalResolution.Height))
+	newWidth := int(float64(originalResolution.Width) * scale)
+	newHeight := int(float64(originalResolution.Height) * scale)
+
+	// Calculate the padding offsets.
+	padX := (targetResolution.Width - newWidth) / 2
+	padY := (targetResolution.Height - newHeight) / 2
+
+	// Check if the coordinate falls within the region containing the scaled image.
+	if point.X < float64(padX) || point.X >= float64(padX+newWidth) || point.Y < float64(padY) || point.Y >= float64(padY+newHeight) {
+		// The coordinate is in the padded area.
+		return nil
+	}
+
+	// Convert padded coordinate to scaled image coordinate.
+	origX := int((point.X - float64(padX)) / scale)
+	origY := int((point.Y - float64(padY)) / scale)
+
+	// Clamp the result to the original image bounds.
+	if origX >= originalResolution.Width {
+		origX = originalResolution.Width - 1
+	}
+	if origY >= originalResolution.Height {
+		origY = originalResolution.Height - 1
+	}
+	return &types.Point{X: float64(origX), Y: float64(origY)}
+}
+
+// RemapPointInverse maps a point from the original image coordinates to the padded image coordinates.
+func RemapPointInverse(point *types.Point, originalResolution *types.Resolution, targetResolution *types.Resolution) *types.Point {
+	// Compute the scale factor used in letterboxing.
+	scale := math.Min(float64(targetResolution.Width)/float64(originalResolution.Width), float64(targetResolution.Height)/float64(originalResolution.Height))
+
+	// Compute new dimensions of the scaled image.
+	newWidth := int(math.Round(float64(originalResolution.Width) * scale))
+	newHeight := int(math.Round(float64(originalResolution.Height) * scale))
+
+	// Calculate padding offsets.
+	padX := (targetResolution.Width - newWidth) / 2
+	padY := (targetResolution.Height - newHeight) / 2
+
+	// Map from original to padded coordinates.
+	targetX := float64(padX) + (point.X * scale)
+	targetY := float64(padY) + (point.Y * scale)
+
+	return &types.Point{X: targetX, Y: targetY}
 }
 
 // DrawPoint draws a point on an image.

--- a/golang/internal/utils/utils.go
+++ b/golang/internal/utils/utils.go
@@ -9,6 +9,7 @@ import (
 	"image/draw"
 	"math"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/antchfx/xmlquery"
@@ -238,18 +239,24 @@ func ExtractFirstUniqueHTMLID(htmlFragment string) (string, error) {
 	return firstID, nil
 }
 
-// GetFloatValue converts a value to a float64.
+// ParseFloatValue tries to parse the given value to a float64.
+//
 // Parameters:
-//   - v: The value to convert
+//   - v: The value to parse
 //
 // Returns:
-//   - float64: The converted value
-func GetFloatValue(v any) float64 {
+//   - float64: The parsed value
+//   - error: An error if the given value is not a float64, int, or string
+func ParseFloatValue(v any) (float64, error) {
 	switch t := v.(type) {
 	case float64:
-		return t
+		return t, nil
+	case int:
+		return float64(t), nil
+	case string:
+		return strconv.ParseFloat(t, 64)
 	default:
-		return float64(v.(int))
+		return 0, fmt.Errorf("unexpected type for float value: %T", v)
 	}
 }
 

--- a/golang/internal/utils/utils_test.go
+++ b/golang/internal/utils/utils_test.go
@@ -310,7 +310,7 @@ func TestExtractFirstUniqueID(t *testing.T) {
 	}
 }
 
-func TestGetFloatValue(t *testing.T) {
+func TestParseFloatValue(t *testing.T) {
 	tests := []struct {
 		name  string
 		input any
@@ -326,11 +326,17 @@ func TestGetFloatValue(t *testing.T) {
 			input: 123,
 			want:  123.0,
 		},
+		{
+			name:  "String input",
+			input: "123.45",
+			want:  123.45,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetFloatValue(tt.input)
+			got, err := ParseFloatValue(tt.input)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/golang/internal/utils/utils_test.go
+++ b/golang/internal/utils/utils_test.go
@@ -299,7 +299,7 @@ func TestExtractFirstUniqueID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ExtractFirstUniqueID(tt.html)
+			got, err := ExtractFirstUniqueHTMLID(tt.html)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/golang/internal/xml/xml.go
+++ b/golang/internal/xml/xml.go
@@ -298,7 +298,7 @@ func GenerateUniqueId(id string) string {
 func AttrsToMap(attrs []xmlquery.Attr) map[string]string {
 	attrMap := make(map[string]string)
 	for _, attr := range attrs {
-		attrMap[attr.Name.Local] = attr.Value
+		attrMap[attr.Name.Local] = strings.ReplaceAll(attr.Value, "\"", "&quot;")
 	}
 	return attrMap
 }

--- a/golang/internal/xml/xml.go
+++ b/golang/internal/xml/xml.go
@@ -248,12 +248,12 @@ func GetVisibleText(
 	element *xmlquery.Node, platform string,
 ) string {
 	if platform == "android" {
-		return strings.TrimSpace(element.SelectAttr("text"))
+		return escapeString(strings.TrimSpace(element.SelectAttr("text")))
 	} else {
 		if labelText := strings.TrimSpace(element.SelectAttr("label")); labelText != "" {
-			return labelText
+			return escapeString(labelText)
 		} else {
-			return strings.TrimSpace(element.SelectAttr("value"))
+			return escapeString(strings.TrimSpace(element.SelectAttr("value")))
 		}
 	}
 }
@@ -297,17 +297,19 @@ func GenerateUniqueId(id string) string {
 	return hex.EncodeToString(md5Hash[:])
 }
 
+func escapeString(str string) string {
+	var buf bytes.Buffer
+	err := xml.EscapeText(&buf, []byte(str))
+	if err != nil {
+		return str
+	}
+	return buf.String()
+}
+
 func AttrsToMap(attrs []xmlquery.Attr) map[string]string {
 	attrMap := make(map[string]string)
 	for _, attr := range attrs {
-		var buf bytes.Buffer
-		err := xml.EscapeText(&buf, []byte(attr.Value))
-		if err != nil {
-			// Handle error or continue with unescaped value
-			attrMap[attr.Name.Local] = attr.Value
-		} else {
-			attrMap[attr.Name.Local] = buf.String()
-		}
+		attrMap[attr.Name.Local] = escapeString(attr.Value)
 	}
 	return attrMap
 }

--- a/golang/internal/xml/xml.go
+++ b/golang/internal/xml/xml.go
@@ -1,9 +1,11 @@
 package xml
 
 import (
+	"bytes"
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"strconv"
 	"strings"
@@ -298,7 +300,14 @@ func GenerateUniqueId(id string) string {
 func AttrsToMap(attrs []xmlquery.Attr) map[string]string {
 	attrMap := make(map[string]string)
 	for _, attr := range attrs {
-		attrMap[attr.Name.Local] = strings.ReplaceAll(attr.Value, "\"", "&quot;")
+		var buf bytes.Buffer
+		err := xml.EscapeText(&buf, []byte(attr.Value))
+		if err != nil {
+			// Handle error or continue with unescaped value
+			attrMap[attr.Name.Local] = attr.Value
+		} else {
+			attrMap[attr.Name.Local] = buf.String()
+		}
 	}
 	return attrMap
 }

--- a/golang/mode/dom-analysis_test.go
+++ b/golang/mode/dom-analysis_test.go
@@ -26,6 +26,11 @@ func (m *MockPlugin) GetMinifiedDOM() (*types.DOM, error) {
 	return args.Get(0).(*types.DOM), args.Error(1)
 }
 
+func (m *MockPlugin) ExtractFirstUniqueID(fragment string) (string, error) {
+	args := m.Called(fragment)
+	return args.String(0), args.Error(1)
+}
+
 func (m *MockPlugin) IsLocatorValid(locator string) (bool, error) {
 	args := m.Called(locator)
 	return args.Bool(0), args.Error(1)

--- a/golang/mode/visual-analysis.go
+++ b/golang/mode/visual-analysis.go
@@ -110,8 +110,6 @@ func (m *VisualAnalysisMode) ProcessRequest(
 		}
 
 		locator := locatorMap[id][0]
-		fmt.Println("ID", id)
-		fmt.Println("LOCATOR", locator)
 		chunkLocation, err := plugin.GetElementLocation(locator)
 		if err != nil {
 			logger.Error("couldn't find chunk on the page", "error", err)

--- a/golang/mode/visual-analysis.go
+++ b/golang/mode/visual-analysis.go
@@ -60,9 +60,11 @@ func (m *VisualAnalysisMode) ProcessRequest(
 
 	pluginName, fields, err := utils.GetStructFields(plugin, "DevicePixelRatio")
 	if err == nil && pluginName == "seleniumPlugin" {
-		devicePixelRatio := fields["DevicePixelRatio"]
-		if devicePixelRatio.IsValid() && utils.GetFloatValue(devicePixelRatio.Interface()) != 1.0 {
-			logger.Warn(deviceScaleFactorWarning)
+		if field := fields["DevicePixelRatio"]; field.IsValid() {
+			ratio, err := utils.ParseFloatValue(field.Interface())
+			if err == nil && ratio != 1.0 {
+				logger.Warn(deviceScaleFactorWarning)
+			}
 		}
 	}
 

--- a/golang/mode/visual-analysis.go
+++ b/golang/mode/visual-analysis.go
@@ -87,8 +87,9 @@ func (m *VisualAnalysisMode) ProcessRequest(
 	for attempt, chunk := range domChunks {
 		logger.Info("Attempt number", "attempt", attempt+1)
 
-		id, err := utils.ExtractFirstUniqueID(chunk)
+		id, err := plugin.ExtractFirstUniqueID(chunk)
 		if err != nil {
+			logger.Error("couldn't extract first unique id", "error", err)
 			continue
 		}
 		if err := plugin.SetViewportSize(m.Resolution.Width, m.Resolution.Height); err != nil {
@@ -156,7 +157,6 @@ func (m *VisualAnalysisMode) ProcessRequest(
 		}
 
 		elementPoint := types.Point{X: xCoord, Y: yCoord}
-		logger.Info("elementPoint", "point", elementPoint)
 		locators, err := plugin.GetElementLocators(&types.Location{
 			Point:          elementPoint,
 			ScrollPosition: chunkLocation.ScrollPosition,

--- a/golang/mode/visual-analysis.go
+++ b/golang/mode/visual-analysis.go
@@ -98,6 +98,8 @@ func (m *VisualAnalysisMode) ProcessRequest(
 		}
 
 		locator := locatorMap[id][0]
+		fmt.Println("ID", id)
+		fmt.Println("LOCATOR", locator)
 		chunkLocation, err := plugin.GetElementLocation(locator)
 		if err != nil {
 			logger.Error("couldn't find chunk on the page", "error", err)

--- a/golang/mode/visual-analysis_test.go
+++ b/golang/mode/visual-analysis_test.go
@@ -31,6 +31,9 @@ func TestVisualAnalysisMode_ProcessRequest(t *testing.T) {
 				Height: 800,
 			},
 			mockSetup: func(mp *MockPlugin, ml *MockLLMClient, mr *MockRerankerClient) {
+				// Add this mock for ExtractFirstUniqueID
+				mp.On("ExtractFirstUniqueID", mock.AnythingOfType("string")).Return("button-123", nil)
+
 				// Mock DOM response
 				mp.On("GetMinifiedDOM").Return(&types.DOM{
 					RootElement: &types.ElementSpec{
@@ -92,6 +95,9 @@ func TestVisualAnalysisMode_ProcessRequest(t *testing.T) {
 				Height: 800,
 			},
 			mockSetup: func(mp *MockPlugin, ml *MockLLMClient, mr *MockRerankerClient) {
+				// Add this mock for ExtractFirstUniqueID
+				mp.On("ExtractFirstUniqueID", mock.AnythingOfType("string")).Return("button-123", nil)
+
 				// Mock DOM response with valid ID that matches the chunk
 				mp.On("GetMinifiedDOM").Return(&types.DOM{
 					RootElement: &types.ElementSpec{
@@ -128,24 +134,6 @@ func TestVisualAnalysisMode_ProcessRequest(t *testing.T) {
 				ml.On("GetJSONCompletion", mock.Anything, mock.Anything).Return(&types.JSONCompletion{
 					JSON: string(jsonBytes),
 				}, nil)
-			},
-			expectedError: "no relevant element point found in the DOM",
-		},
-		{
-			name:    "empty DOM",
-			request: "find button",
-			resolution: &types.Resolution{
-				Width:  1280,
-				Height: 800,
-			},
-			mockSetup: func(mp *MockPlugin, ml *MockLLMClient, mr *MockRerankerClient) {
-				mp.On("GetMinifiedDOM").Return(&types.DOM{
-					RootElement: &types.ElementSpec{},
-					Metadata:    &types.DOMMetadata{},
-				}, nil)
-
-				// Mock reranker to return empty results
-				mr.On("Rerank", mock.Anything).Return([]types.RerankResult{}, nil)
 			},
 			expectedError: "no relevant element point found in the DOM",
 		},

--- a/golang/plugins/appium.go
+++ b/golang/plugins/appium.go
@@ -235,7 +235,7 @@ func (plugin *appiumPlugin) TakeScreenshot() ([]byte, error) {
 	return imageBytes, nil
 }
 
-func calculateAndroindElementCenter(attributes map[string]string) (*types.Point, error) {
+func calculateAndroidElementCenter(attributes map[string]string) (*types.Point, error) {
 	re := regexp.MustCompile(`\[(\d+),(\d+)\]\[(\d+),(\d+)\]`)
 	matches := re.FindStringSubmatch(attributes["bounds"])
 	if len(matches) != 5 {
@@ -296,7 +296,7 @@ func calculateIOSElementCenter(attributes map[string]string) (*types.Point, erro
 func (plugin *appiumPlugin) calculateElementCenter(attributes map[string]string) (*types.Point, error) {
 	switch plugin.PlatformName {
 	case "android":
-		return calculateAndroindElementCenter(attributes)
+		return calculateAndroidElementCenter(attributes)
 	case "ios":
 		return calculateIOSElementCenter(attributes)
 	default:

--- a/golang/plugins/appium.go
+++ b/golang/plugins/appium.go
@@ -1,29 +1,53 @@
 package plugins
 
 import (
+	"bytes"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"image/png"
+	"math"
+	"regexp"
+	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/vertexcover-io/locatr/golang/internal/appium"
 	"github.com/vertexcover-io/locatr/golang/internal/constants"
 	"github.com/vertexcover-io/locatr/golang/internal/utils"
 	"github.com/vertexcover-io/locatr/golang/internal/xml"
+	"github.com/vertexcover-io/locatr/golang/logging"
 	"github.com/vertexcover-io/locatr/golang/types"
 )
 
+// appiumPlugin encapsulates browser automation functionality using the Appium client.
 type appiumPlugin struct {
-	client *appium.Client
+	client             *appium.Client
+	originalResolution *types.Resolution
+	targetResolution   *types.Resolution
 }
 
+// NewAppiumPlugin initializes a new plugin instance with the provided Appium client.
+//
+// Parameters:
+//   - serverUrl: The URL of the Appium server
+//   - sessionId: The ID of the Appium session
 func NewAppiumPlugin(serverUrl, sessionId string) (*appiumPlugin, error) {
 	client, err := appium.NewClient(serverUrl, sessionId)
 	if err != nil {
 		return nil, err
 	}
-	return &appiumPlugin{client: client}, nil
+	plugin := &appiumPlugin{client: client}
+	_, _ = plugin.TakeScreenshot() // This will set the original resolution
+	return plugin, nil
 }
 
+// evaluateJSExpression executes a JavaScript expression in the context of the current page.
+// If the script is not attached, it will be attached first.
+//
+// Parameters:
+//   - expression: The JavaScript code to execute
+//   - args: Optional arguments to pass to the expression
 func (plugin *appiumPlugin) evaluateJSExpression(expression string, args ...any) (any, error) {
 	// Check if script is already attached
 	isAttached, err := plugin.client.ExecuteScript("return window.locatrScriptAttached === true", []any{})
@@ -41,6 +65,7 @@ func (plugin *appiumPlugin) evaluateJSExpression(expression string, args ...any)
 	return result, nil
 }
 
+// minifyHTML retrieves the minified DOM from the current page.
 func (plugin *appiumPlugin) minifyHTML() (*types.DOM, error) {
 	result, err := plugin.evaluateJSExpression("minifyHTML()")
 	if err != nil {
@@ -71,6 +96,7 @@ func (plugin *appiumPlugin) minifyHTML() (*types.DOM, error) {
 	return dom, nil
 }
 
+// minifyXML retrieves the minified DOM from the current page.
 func (plugin *appiumPlugin) minifyXML() (*types.DOM, error) {
 	pageSource, err := plugin.client.GetPageSource()
 	if err != nil {
@@ -101,6 +127,7 @@ func (plugin *appiumPlugin) minifyXML() (*types.DOM, error) {
 	return dom, nil
 }
 
+// GetCurrentContext retrieves the current context of the plugin.
 func (plugin *appiumPlugin) GetCurrentContext() (*string, error) {
 	caps, err := plugin.client.GetCapabilities()
 	if err != nil {
@@ -116,6 +143,7 @@ func (plugin *appiumPlugin) GetCurrentContext() (*string, error) {
 	return nil, errors.New("no context found")
 }
 
+// GetMinifiedDOM retrieves the minified DOM from the current page.
 func (plugin *appiumPlugin) GetMinifiedDOM() (*types.DOM, error) {
 	if plugin.client.IsWebView() {
 		return plugin.minifyHTML()
@@ -123,26 +151,247 @@ func (plugin *appiumPlugin) GetMinifiedDOM() (*types.DOM, error) {
 	return plugin.minifyXML()
 }
 
-func (plugin *appiumPlugin) IsLocatorValid(locator string) (bool, error) {
-	if err := plugin.client.FindElement(locator); err == nil {
-		return true, nil
-	} else {
-		return false, err
+// ExtractFirstUniqueID extracts the first unique ID from the given fragment.
+func (plugin *appiumPlugin) ExtractFirstUniqueID(fragment string) (string, error) {
+	if plugin.client.IsWebView() {
+		return utils.ExtractFirstUniqueHTMLID(fragment)
 	}
+	return utils.ExtractFirstUniqueXMLID(fragment)
 }
 
+// IsLocatorValid verifies if the given locator is valid.
+func (plugin *appiumPlugin) IsLocatorValid(locator string) (bool, error) {
+	var locatrType string
+	if plugin.client.IsWebView() {
+		locatrType = "css selector"
+	} else {
+		locatrType = "xpath"
+	}
+	_, err := plugin.client.FindElement(locatrType, locator)
+	return err == nil, err
+}
+
+// SetViewportSize sets the viewport size.
 func (plugin *appiumPlugin) SetViewportSize(width, height int) error {
-	return errors.New("not implemented")
+	// We don't actually set the viewport size, we just
+	// store the resolution for scaling the screenshot
+	plugin.targetResolution = &types.Resolution{Width: width, Height: height}
+	return nil
 }
 
+// TakeScreenshot captures a screenshot of the current viewport.
 func (plugin *appiumPlugin) TakeScreenshot() ([]byte, error) {
-	return nil, errors.New("not implemented")
+	base64Image, err := plugin.client.ExecuteScript("mobile: viewportScreenshot", []any{})
+	if err != nil {
+		return nil, err
+	}
+	imageBytes, err := base64.StdEncoding.DecodeString(base64Image.(string))
+	if err != nil {
+		return nil, err
+	}
+
+	img, err := png.Decode(bytes.NewReader(imageBytes))
+	if err != nil {
+		return nil, err
+	}
+	plugin.originalResolution = &types.Resolution{
+		Width:  img.Bounds().Dx(),
+		Height: img.Bounds().Dy(),
+	}
+
+	if plugin.targetResolution != nil {
+		scaledBytes := utils.ScaleAndPadImage(img, plugin.targetResolution)
+		var buf bytes.Buffer
+		if err := png.Encode(&buf, scaledBytes); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	}
+
+	return imageBytes, nil
 }
 
+// parseAndCalculateCenter parses the coordinates and calculates the center of the element.
+func parseAndCalculateCenter(x, y, width, height string) (*types.Point, error) {
+	x1, err := strconv.Atoi(x)
+	if err != nil {
+		return nil, fmt.Errorf("invalid x1 coordinate: %v", err)
+	}
+
+	y1, err := strconv.Atoi(y)
+	if err != nil {
+		return nil, fmt.Errorf("invalid y1 coordinate: %v", err)
+	}
+
+	x2, err := strconv.Atoi(width)
+	if err != nil {
+		return nil, fmt.Errorf("invalid x2 coordinate: %v", err)
+	}
+
+	y2, err := strconv.Atoi(height)
+	if err != nil {
+		return nil, fmt.Errorf("invalid y2 coordinate: %v", err)
+	}
+
+	// Calculate center
+	centerX := (x1 + x2) / 2
+	centerY := (y1 + y2) / 2
+
+	return &types.Point{X: float64(centerX), Y: float64(centerY)}, nil
+}
+
+// parseBoundsAndCalculateCenter parses the bounds and calculates the center of the element.
+func (plugin *appiumPlugin) parseBoundsAndCalculateCenter(bounds string) (*types.Point, error) {
+	re := regexp.MustCompile(`\[(\d+),(\d+)\]\[(\d+),(\d+)\]`)
+	matches := re.FindStringSubmatch(bounds)
+	if len(matches) != 5 {
+		return nil, fmt.Errorf("invalid bounds format: %s", bounds)
+	}
+	return parseAndCalculateCenter(matches[1], matches[2], matches[3], matches[4])
+}
+
+// candidate represents a candidate element and its score.
+type candidate struct {
+	element *types.ElementSpec
+	score   float64
+}
+
+// GetElementLocators retrieves locators from a given point and scroll position on the page.
 func (plugin *appiumPlugin) GetElementLocators(location *types.Location) ([]string, error) {
-	return nil, errors.New("not implemented")
+	// Remap the incoming location to original coordinates.
+	if plugin.targetResolution != nil && plugin.originalResolution != nil {
+		location.Point = *utils.RemapPoint(&location.Point, plugin.originalResolution, plugin.targetResolution)
+	}
+
+	caps, err := plugin.client.GetCapabilities()
+	if err != nil {
+		return nil, err
+	}
+	platform := strings.ToLower(caps.Value.PlatformName)
+
+	candidateChan := make(chan candidate, 10)
+	var wg sync.WaitGroup
+
+	var searchElement func(element *types.ElementSpec)
+	searchElement = func(element *types.ElementSpec) {
+		defer wg.Done()
+
+		var elementPoint *types.Point
+		attrs := element.Attributes
+
+		if platform == "android" && attrs["bounds"] != "" {
+			elementPoint, err = plugin.parseBoundsAndCalculateCenter(attrs["bounds"])
+		} else if platform == "ios" && attrs["x"] != "" && attrs["y"] != "" {
+			elementPoint, err = parseAndCalculateCenter(attrs["x"], attrs["y"], attrs["width"], attrs["height"])
+		}
+		if err != nil {
+			logging.DefaultLogger.Error("failed to calculate center", "error", err)
+		}
+
+		if elementPoint != nil {
+			score := math.Abs(location.Point.X-elementPoint.X) + math.Abs(location.Point.Y-elementPoint.Y)
+			select {
+			case candidateChan <- candidate{element: element, score: score}:
+			default:
+			}
+		}
+
+		for i := range element.Children {
+			wg.Add(1)
+			go searchElement(&element.Children[i])
+		}
+	}
+
+	dom, err := plugin.GetMinifiedDOM()
+	if err != nil {
+		return nil, err
+	}
+
+	wg.Add(1)
+	go searchElement(dom.RootElement)
+
+	go func() {
+		wg.Wait()
+		close(candidateChan)
+	}()
+
+	var best *candidate
+	for cand := range candidateChan {
+		if best == nil || cand.score < best.score {
+			best = &cand
+		}
+	}
+
+	if best == nil {
+		return nil, errors.New("element not found at given location")
+	}
+
+	return dom.Metadata.LocatorMap[best.element.Id], nil
 }
 
+// GetElementLocation retrieves the location of the element associated with the given locator.
 func (plugin *appiumPlugin) GetElementLocation(locator string) (*types.Location, error) {
-	return nil, errors.New("not implemented")
+
+	uniqueId := xml.GenerateUniqueId(locator)
+	resultChan := make(chan *types.ElementSpec, 1)
+	var wg sync.WaitGroup
+
+	var searchElement func(element *types.ElementSpec)
+	searchElement = func(element *types.ElementSpec) {
+		defer wg.Done()
+
+		if element.Id == uniqueId {
+			select {
+			case resultChan <- element:
+			default:
+			}
+			return
+		}
+
+		for _, child := range element.Children {
+			wg.Add(1)
+			go searchElement(&child)
+		}
+	}
+
+	dom, err := plugin.GetMinifiedDOM()
+	if err != nil {
+		return nil, err
+	}
+
+	wg.Add(1)
+	go searchElement(dom.RootElement)
+
+	go func() {
+		wg.Wait()
+		close(resultChan)
+	}()
+
+	caps, err := plugin.client.GetCapabilities()
+	if err != nil {
+		return nil, err
+	}
+	platform := strings.ToLower(caps.Value.PlatformName)
+
+	select {
+	case result := <-resultChan:
+		attrs := result.Attributes
+		var elementPoint *types.Point
+
+		if platform == "android" && attrs["bounds"] != "" {
+			elementPoint, err = plugin.parseBoundsAndCalculateCenter(attrs["bounds"])
+		} else if platform == "ios" && attrs["x"] != "" && attrs["y"] != "" {
+			elementPoint, err = parseAndCalculateCenter(attrs["x"], attrs["y"], attrs["width"], attrs["height"])
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to calculate center: %v", err)
+		}
+
+		if plugin.targetResolution != nil && plugin.originalResolution != nil {
+			elementPoint = utils.RemapPointInverse(elementPoint, plugin.originalResolution, plugin.targetResolution)
+		}
+		return &types.Location{Point: *elementPoint, ScrollPosition: types.Point{X: 0.0, Y: 0.0}}, nil
+	default:
+		return nil, fmt.Errorf("could not locate element associated with locator: %s", locator)
+	}
 }

--- a/golang/plugins/playwright.go
+++ b/golang/plugins/playwright.go
@@ -94,6 +94,11 @@ func (plugin *playwrightPlugin) GetMinifiedDOM() (*types.DOM, error) {
 	return dom, nil
 }
 
+// ExtractFirstUniqueID extracts the first unique ID from the given fragment.
+func (plugin *playwrightPlugin) ExtractFirstUniqueID(fragment string) (string, error) {
+	return utils.ExtractFirstUniqueHTMLID(fragment)
+}
+
 // IsLocatorValid checks if a given CSS selector matches any elements on the page.
 //
 // Parameters:

--- a/golang/plugins/playwright.go
+++ b/golang/plugins/playwright.go
@@ -11,9 +11,14 @@ import (
 )
 
 // playwrightPlugin encapsulates browser automation functionality using the Playwright framework.
+//
+// Attributes:
+//   - BrowserName: Name of the browser (e.g. "chromium", "firefox", "webkit", etc.)
 type playwrightPlugin struct {
 	// Playwright page instance
 	page *playwright.Page
+	// Name of the browser (e.g. "chromium", "firefox", "webkit", etc.)
+	BrowserName string
 }
 
 // NewPlaywrightPlugin initializes a new plugin instance with the provided Playwright page.
@@ -22,8 +27,9 @@ type playwrightPlugin struct {
 //   - page: Pointer to a configured Playwright page instance
 //
 // Returns the initialized Playwright plugin.
-func NewPlaywrightPlugin(page *playwright.Page) *playwrightPlugin {
-	return &playwrightPlugin{page: page}
+func NewPlaywrightPlugin(page *playwright.Page) (*playwrightPlugin, error) {
+	browserName := (*page).Context().Browser().BrowserType().Name()
+	return &playwrightPlugin{page: page, BrowserName: browserName}, nil
 }
 
 // evaluateExpression executes a JavaScript expression in the context of the current page.

--- a/golang/plugins/selenium.go
+++ b/golang/plugins/selenium.go
@@ -11,9 +11,17 @@ import (
 )
 
 // seleniumPlugin encapsulates browser automation functionality using the Selenium WebDriver.
+//
+// Attributes:
+//   - BrowserName: Name of the browser (e.g. "chrome", "firefox", etc.)
+//   - DevicePixelRatio: Device pixel ratio of the browser
 type seleniumPlugin struct {
 	// Selenium WebDriver instance
 	driver *selenium.WebDriver
+	// Name of the browser (e.g. "chrome", "firefox", etc.)
+	BrowserName string
+	// Device pixel ratio of the browser
+	DevicePixelRatio float64
 }
 
 // NewSeleniumPlugin initializes a new seleniumPlugin instance with the provided Selenium WebDriver.
@@ -22,8 +30,23 @@ type seleniumPlugin struct {
 //   - driver: Pointer to a configured Selenium WebDriver instance
 //
 // Returns the initialized plugin.
-func NewSeleniumPlugin(driver *selenium.WebDriver) *seleniumPlugin {
-	return &seleniumPlugin{driver: driver}
+func NewSeleniumPlugin(driver *selenium.WebDriver) (*seleniumPlugin, error) {
+	caps, err := (*driver).Capabilities()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get capabilities: %s", err.Error())
+	}
+
+	devicePixelRatio, err := (*driver).ExecuteScript("return window.devicePixelRatio", []any{})
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get device pixel ratio: %s", err.Error())
+	}
+
+	plugin := &seleniumPlugin{
+		driver:           driver,
+		BrowserName:      caps["browserName"].(string),
+		DevicePixelRatio: utils.GetFloatValue(devicePixelRatio),
+	}
+	return plugin, nil
 }
 
 // evaluateExpression executes a JavaScript expression in the current context.

--- a/golang/plugins/selenium.go
+++ b/golang/plugins/selenium.go
@@ -96,6 +96,11 @@ func (plugin *seleniumPlugin) GetMinifiedDOM() (*types.DOM, error) {
 	return dom, nil
 }
 
+// ExtractFirstUniqueID extracts the first unique ID from the given fragment.
+func (plugin *seleniumPlugin) ExtractFirstUniqueID(fragment string) (string, error) {
+	return utils.ExtractFirstUniqueHTMLID(fragment)
+}
+
 // IsLocatorValid checks if a given CSS selector matches any elements on the page.
 //
 // Parameters:

--- a/golang/reranker/reranker.go
+++ b/golang/reranker/reranker.go
@@ -164,9 +164,9 @@ func requestCohere(client *cohereclient.Client, model string, request *types.Rer
 		context.Background(),
 		&cohere.RerankRequest{
 			Query:     request.Query,
-			Model:     types.Ptr(model),
+			Model:     &model,
 			Documents: rerankDocs,
-			TopN:      types.Ptr(request.TopN),
+			TopN:      &request.TopN,
 		},
 	)
 	if err != nil {

--- a/golang/types/common.go
+++ b/golang/types/common.go
@@ -5,11 +5,6 @@ import (
 	"math"
 )
 
-// Ptr returns a pointer to a value.
-func Ptr[T any](v T) *T {
-	return &v
-}
-
 // Point represents a coordinate point in a 2D space.
 type Point struct {
 	X float64 `json:"x"` // X-coordinate

--- a/golang/types/plugin.go
+++ b/golang/types/plugin.go
@@ -17,6 +17,9 @@ type PluginInterface interface {
 	// GetMinifiedDOM retrieves the minified DOM and associated metadata of the current context.
 	GetMinifiedDOM() (*DOM, error)
 
+	// ExtractFirstUniqueID extracts the first unique ID from the given fragment.
+	ExtractFirstUniqueID(fragment string) (string, error)
+
 	// IsLocatorValid verifies if the given locator is valid.
 	IsLocatorValid(locator string) (bool, error)
 

--- a/server/main.go
+++ b/server/main.go
@@ -56,13 +56,19 @@ func handleInitialHandshake(message incomingMessage, logger *slog.Logger) error 
 		if err != nil {
 			return fmt.Errorf("could not connect to browser: %v", err)
 		}
-		plugin = plugins.NewPlaywrightPlugin(&browser.Contexts()[0].Pages()[0])
+		plugin, err = plugins.NewPlaywrightPlugin(&browser.Contexts()[0].Pages()[0])
+		if err != nil {
+			return fmt.Errorf("could not create playwright plugin: %v", err)
+		}
 	case "selenium":
 		driver, err := selenium.ConnectRemote(settings.SeleniumUrl, settings.SeleniumSessionId)
 		if err != nil {
 			return fmt.Errorf("unable to connect to remote selenium instance: %w", err)
 		}
-		plugin = plugins.NewSeleniumPlugin(&driver)
+		plugin, err = plugins.NewSeleniumPlugin(&driver)
+		if err != nil {
+			return fmt.Errorf("could not create selenium plugin: %v", err)
+		}
 	case "appium":
 		plugin, err = plugins.NewAppiumPlugin(settings.AppiumUrl, settings.AppiumSessionId)
 		if err != nil {


### PR DESCRIPTION
# Overview

- Scales and pads images for coordinate generation as setting custom viewport is not supported in native apps.
- Remaps the cooridnate based on original and target (custom viewport) resolution
- Finding locators from coordinate is achieved through parsing bounds from attributes of elements in minified DOM tree.
- Finding coordinate from locator is achieved through regenerating the unique id from the given locator itself which is then used for finding the element in minified DOM tree.

## More updates:

- **Store metadata during plugin creation**:
  - `selenium`: browser name and device pixel ratio
  - `playwright`: browser name
  - `appium`: platform name (reduces API calls)

- **Fix race condition in appium plugin's `GetElementLocation` method**:
  - `Problem`: Non-blocking select with default case caused premature exits before goroutines could start or find elements
  - `Solution`: Replace default case with 3-second background context timeout
  - `Impact`: Ensures proper wait time for element search completion

- Show warning while using visual analysis mode when Selenium driver's device scale factor is not 1.0, which can affect custom viewport sizing and lead to incorrect element locations. Warning suggests using `--force-device-scale-factor=1` flag when creating the driver

- Add support for appium session creation from capabilities directly from locatr golang package