### PR TITLE
feat: add cached plugin support in ipc

### DIFF
--- a/ipc/python_client/locatr/_utils.py
+++ b/ipc/python_client/locatr/_utils.py
@@ -81,10 +81,10 @@ def log_output(process: Popen[bytes]):
 
 
 def create_packed_message(message_str: str) -> bytes:
-    message_length = len(message_str)
-    version_bytes = bytes(VERSION)
-    packed_data = struct.pack(">3B", *version_bytes) + struct.pack(
-        f">I{message_length}s", message_length, message_str.encode()
+    message_bytes = message_str.encode()
+    message_length = len(message_bytes)
+    packed_data = struct.pack(">3B I", *VERSION, message_length) + struct.pack(
+        f">{message_length}s", message_bytes
     )
     return packed_data
 

--- a/ipc/server/cachedPlugin.go
+++ b/ipc/server/cachedPlugin.go
@@ -12,7 +12,7 @@ type cachedPlugin struct {
 	currentContext string
 }
 
-func CachePlugin(plugin types.PluginInterface) types.PluginInterface {
+func NewCachedPlugin(plugin types.PluginInterface) *cachedPlugin {
 	return &cachedPlugin{plugin: plugin}
 }
 

--- a/ipc/server/cachedPlugin.go
+++ b/ipc/server/cachedPlugin.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+
+	"github.com/vertexcover-io/locatr/pkg/types"
+)
+
+type cachedPlugin struct {
+	plugin         types.PluginInterface
+	minifiedDOM    *types.DOM
+	currentContext string
+}
+
+func CachePlugin(plugin types.PluginInterface) types.PluginInterface {
+	return &cachedPlugin{plugin: plugin}
+}
+
+func (p *cachedPlugin) GetCurrentContext(ctx context.Context) (*string, error) {
+	if p.currentContext != "" {
+		return &p.currentContext, nil
+	}
+	currentContext, err := p.plugin.GetCurrentContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	p.currentContext = *currentContext
+	return currentContext, nil
+}
+
+func (p *cachedPlugin) GetMinifiedDOM(ctx context.Context) (*types.DOM, error) {
+	if p.minifiedDOM != nil {
+		return p.minifiedDOM, nil
+	}
+	dom, err := p.plugin.GetMinifiedDOM(ctx)
+	if err != nil {
+		return nil, err
+	}
+	p.minifiedDOM = dom
+	return dom, nil
+}
+
+func (p *cachedPlugin) ExtractFirstUniqueID(ctx context.Context, fragment string) (string, error) {
+	return p.plugin.ExtractFirstUniqueID(ctx, fragment)
+}
+
+func (p *cachedPlugin) IsLocatorValid(ctx context.Context, locator string) (bool, error) {
+	return p.plugin.IsLocatorValid(ctx, locator)
+}
+
+func (p *cachedPlugin) SetViewportSize(ctx context.Context, width, height int) error {
+	return p.plugin.SetViewportSize(ctx, width, height)
+}
+
+func (p *cachedPlugin) TakeScreenshot(ctx context.Context) ([]byte, error) {
+	return p.plugin.TakeScreenshot(ctx)
+}
+
+func (p *cachedPlugin) GetElementLocators(ctx context.Context, location *types.Location) ([]string, error) {
+	return p.plugin.GetElementLocators(ctx, location)
+}
+
+func (p *cachedPlugin) GetElementLocation(ctx context.Context, locator string) (*types.Location, error) {
+	return p.plugin.GetElementLocation(ctx, locator)
+}

--- a/ipc/server/main.go
+++ b/ipc/server/main.go
@@ -75,6 +75,7 @@ func handleInitialHandshake(message incomingMessage, logger *slog.Logger) error 
 		if err != nil {
 			return fmt.Errorf("unable to create appium plugin: %w", err)
 		}
+		plugin = CachePlugin(plugin)
 	}
 	llmSettings := settings.LlmSettings
 	llmClient, err := llm.NewLLMClient(

--- a/ipc/server/main.go
+++ b/ipc/server/main.go
@@ -71,6 +71,7 @@ func handleInitialHandshake(message incomingMessage, logger *slog.Logger) error 
 		if err != nil {
 			return fmt.Errorf("could not create selenium plugin: %v", err)
 		}
+		plugin = NewCachedPlugin(plugin)
 	case "appium":
 		plugin, err = plugins.NewAppiumPlugin(settings.AppiumUrl, settings.AppiumSessionId)
 		if err != nil {

--- a/ipc/server/main.go
+++ b/ipc/server/main.go
@@ -76,8 +76,9 @@ func handleInitialHandshake(message incomingMessage, logger *slog.Logger) error 
 		if err != nil {
 			return fmt.Errorf("unable to create appium plugin: %w", err)
 		}
-		plugin = CachePlugin(plugin)
+		plugin = NewCachedPlugin(plugin)
 	}
+
 	llmSettings := settings.LlmSettings
 	llmClient, err := llm.NewLLMClient(
 		llm.WithProvider(types.LLMProvider(llmSettings.LlmProvider)),

--- a/pkg/internal/appium/appium.go
+++ b/pkg/internal/appium/appium.go
@@ -62,10 +62,6 @@ type findElementRequest struct {
 	Using string `json:"using"`
 }
 
-type getActivityResponse struct {
-	Value string `json:"value"`
-}
-
 var ErrSessionNotActive = errors.New("session not active")
 var ErrCreatingSessionFailed = errors.New("failed creating session")
 var ErrEvaulatingScriptFailed = errors.New("failed evaulating script")
@@ -168,7 +164,7 @@ type resp struct {
 	Value any `json:"value"`
 }
 
-func (c *Client) ExecuteScript(ctx context.Context, script string, args []any) (any, error) {
+func (c *Client) ExecuteScript(ctx context.Context, script string, args ...any) (any, error) {
 	defer logging.CreateTopic("Appium: ExecuteScript", logging.DefaultLogger)()
 
 	bodyJson, err := json.Marshal(map[string]any{"script": script, "args": args})
@@ -275,19 +271,4 @@ func (c *Client) FindElement(ctx context.Context, using, value string) (*string,
 
 	elementId := res["value"]["ELEMENT"]
 	return &elementId, nil
-}
-
-func (c *Client) GetCurrentActivity(ctx context.Context) (string, error) {
-	defer logging.CreateTopic("Appium: GetCurrentActivity", logging.DefaultLogger)()
-
-	response, err := c.httpClient.R().SetResult(&getActivityResponse{}).Get("appium/device/current_activity")
-	if err != nil {
-		return "", fmt.Errorf("%w : %w", ErrFailedConnectingToAppiumServer, err)
-	}
-
-	r := response.Result().(*getActivityResponse)
-	if response.StatusCode() != 200 {
-		return "", fmt.Errorf("%w : %s", ErrSessionNotActive, c.sessionId)
-	}
-	return r.Value, nil
 }

--- a/pkg/internal/appium/appium_test.go
+++ b/pkg/internal/appium/appium_test.go
@@ -208,25 +208,6 @@ func (s *AppiumTestSuite) TestFindElement() {
 	}
 }
 
-func (s *AppiumTestSuite) TestGetCurrentActivity() {
-	s.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(s.T(), "/session/test-session-id/appium/device/current_activity", r.URL.Path)
-		assert.Equal(s.T(), http.MethodGet, r.Method)
-
-		// Set proper content type
-		w.Header().Set("Content-Type", "application/json")
-		// Return the response in the exact format expected by getActivityResponse
-		err := json.NewEncoder(w).Encode(&getActivityResponse{
-			Value: ".MainActivity",
-		})
-		s.Require().NoError(err)
-	})
-
-	activity, err := s.client.GetCurrentActivity(context.Background())
-	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), ".MainActivity", activity)
-}
-
 func (s *AppiumTestSuite) TestExecuteScript_ServerError() {
 	s.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -284,17 +265,6 @@ func (s *AppiumTestSuite) TestGetPageSource_UnmarshalError() {
 	assert.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "failed to unmarshal response")
 	assert.Empty(s.T(), source)
-}
-
-func (s *AppiumTestSuite) TestGetCurrentActivity_ServerError() {
-	s.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	})
-
-	activity, err := s.client.GetCurrentActivity(context.Background())
-	assert.Error(s.T(), err)
-	assert.Contains(s.T(), err.Error(), ErrSessionNotActive.Error())
-	assert.Empty(s.T(), activity)
 }
 
 func (s *AppiumTestSuite) TestExecuteScript_ConnectionError() {


### PR DESCRIPTION
This PR introduces cached plugin specifically for appium in IPC server that satisfies changes (https://github.com/vertexcover-io/locatr/pull/36/commits/267baa5c914fc34db0f1304c50a95c3e28446f49 )made by @Hungerarray.

Overview:
- Capabilities are stored when appium client created from given session ID. This update was made here (https://github.com/vertexcover-io/locatr/pull/44/commits/ecbe1b9e8bf18d86c1d800cc0460e8364c7ec65f#diff-e9c406e9d13c411aa89cb2d680fe688b942f92d6af5b445247dd38eeaccc45aaR19) and it is equivalent to caching capabilities here (https://github.com/vertexcover-io/locatr/pull/36/commits/267baa5c914fc34db0f1304c50a95c3e28446f49#diff-d2179aefd0deb4f1c39eca1087ad2626ac56d1f02a1e5df0994dfd5aa796751aR104)

- Current context is cached on first call. This is equivalent to caching current activity here (https://github.com/vertexcover-io/locatr/pull/36/commits/267baa5c914fc34db0f1304c50a95c3e28446f49#diff-d2179aefd0deb4f1c39eca1087ad2626ac56d1f02a1e5df0994dfd5aa796751aR118)

- Minified DOM is cached on first call. This is equivalent to caching page source here (https://github.com/vertexcover-io/locatr/pull/36/commits/267baa5c914fc34db0f1304c50a95c3e28446f49#diff-d2179aefd0deb4f1c39eca1087ad2626ac56d1f02a1e5df0994dfd5aa796751aR83). This also ensures that the source is only minified once.

---

Other updates:

- Removed `GetCurrentActivity` method from appium client as it is android specific feature

- `appium/device/current_activity` endpoint returns error, now `mobile getCurrentActivity` method is evaluated to get the current activity of android. This reduces overall request time and caching works perfectly for android!